### PR TITLE
Add marker tables with geospatial index

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,3 +2,14 @@
 
 Cartella dedicata allo sviluppo del server e dell'API dell'applicazione.
 Note iniziali: definire la struttura del progetto e la logica di business.
+
+## Struttura del database
+
+Il database SQLite inizializza automaticamente le seguenti tabelle:
+
+- **users**: credenziali e ruoli degli utenti.
+- **markers**: punti sulla mappa con latitudine, longitudine, nome,
+  descrizione, autore e timestamp di creazione. È presente un indice su
+  `lat` e `lng` per facilitare le ricerche geospaziali.
+- **marker_images**: immagini associate ai marker con URL e didascalia,
+  collegate tramite chiave esterna a `markers`.

--- a/backend/db.js
+++ b/backend/db.js
@@ -4,12 +4,34 @@ const path = require('path');
 const db = new sqlite3.Database(path.join(__dirname, 'data.sqlite'));
 
 db.serialize(() => {
+  db.run('PRAGMA foreign_keys = ON');
+
   db.run(`CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT UNIQUE,
     password_hash TEXT,
     role TEXT
   )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS markers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    lat REAL NOT NULL,
+    lng REAL NOT NULL,
+    nome TEXT,
+    descrizione TEXT,
+    autore TEXT,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS marker_images (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    marker_id INTEGER,
+    url TEXT,
+    didascalia TEXT,
+    FOREIGN KEY(marker_id) REFERENCES markers(id) ON DELETE CASCADE
+  )`);
+
+  db.run(`CREATE INDEX IF NOT EXISTS idx_markers_lat_lng ON markers(lat, lng)`);
 });
 
 module.exports = db;


### PR DESCRIPTION
## Summary
- create `markers` and `marker_images` tables with foreign key relations
- index marker latitude/longitude for faster geospatial lookup
- document database tables in backend README

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e53d5ec3c8327adbaf7cced4f13ca