### PR TITLE
feat(frontend): add leaflet map with markers

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,9 @@
 # Frontend
 
 Contiene il codice per l'interfaccia utente dell'applicazione.
-Note iniziali: scegliere il framework e impostare la base del progetto.
+
+La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap e recupera i marker dal backend tramite `GET /markers`. Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
+
+Per testare l'interfaccia:
+1. avviare il server nella cartella `backend` (`npm start`);
+2. aprire `frontend/index.html` in un browser.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,42 @@
+const map = L.map('map').setView([0, 0], 2);
+
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);
+
+fetch('/markers')
+  .then((response) => {
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    return response.json();
+  })
+  .then((markers) => {
+    markers.forEach((marker) => {
+      const popupContent = createPopupContent(marker);
+      L.marker([marker.lat, marker.lng]).addTo(map).bindPopup(popupContent);
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to load markers', err);
+  });
+
+function createPopupContent(marker) {
+  let html = '';
+  if (marker.nome) {
+    html += `<h3>${marker.nome}</h3>`;
+  }
+  if (marker.descrizione) {
+    html += `<p>${marker.descrizione}</p>`;
+  }
+  if (Array.isArray(marker.images) && marker.images.length) {
+    html += '<div class="popup-images">';
+    marker.images.forEach((img) => {
+      const caption = img.didascalia ? `alt="${img.didascalia}"` : '';
+      html += `<img src="${img.url}" ${caption}>`;
+    });
+    html += '</div>';
+  }
+  return html;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Eolobtsmap</title>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-sA+e2myLsY5LCoIFzDwKjNoT0HdrzDo2S1W2YoH4y+o="
+    crossorigin=""
+  />
+  <style>
+    #map {
+      height: 100vh;
+      width: 100%;
+    }
+    .popup-images img {
+      max-width: 100%;
+      display: block;
+      margin-top: 4px;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-o9N1j7kP5ZSk+ieT1pO9MY+rF1rPe/nj1gGUU9SLE0k="
+    crossorigin=""
+  ></script>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Leaflet-based page that fetches and shows markers with popups
- document frontend usage

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688e5bd9ceec832793bc3d3dc80929b2