### PR TITLE
feat: support editing markers in frontend

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,8 +2,13 @@ const map = L.map('map').setView([0, 0], 2);
 
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 19,
-  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  attribution:
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 }).addTo(map);
+
+const markersById = {};
+const modal = document.getElementById('markerModal');
+const form = document.getElementById('markerForm');
 
 fetch('/markers')
   .then((response) => {
@@ -14,13 +19,135 @@ fetch('/markers')
   })
   .then((markers) => {
     markers.forEach((marker) => {
-      const popupContent = createPopupContent(marker);
-      L.marker([marker.lat, marker.lng]).addTo(map).bindPopup(popupContent);
+      addMarker(marker);
     });
   })
   .catch((err) => {
     console.error('Failed to load markers', err);
   });
+
+map.on('click', (e) => {
+  openModal({ lat: e.latlng.lat, lng: e.latlng.lng, images: [] });
+});
+
+document.getElementById('cancelModal').addEventListener('click', () => {
+  modal.classList.remove('show');
+});
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const id = document.getElementById('markerId').value;
+  const marker = {
+    nome: document.getElementById('markerName').value,
+    descrizione: document.getElementById('markerDesc').value,
+    lat: parseFloat(document.getElementById('markerLat').value),
+    lng: parseFloat(document.getElementById('markerLng').value),
+    images: [],
+  };
+  if (id) {
+    marker.id = Number(id);
+    if (markersById[id]) {
+      marker.images = markersById[id].data.images || [];
+    }
+  }
+  const method = id ? 'PUT' : 'POST';
+  const url = id ? `/markers/${id}` : '/markers';
+  fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(marker),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
+      return res.json().catch(() => ({}));
+    })
+    .then((data) => {
+      modal.classList.remove('show');
+      if (id) {
+        const existing = markersById[id];
+        existing.data.nome = marker.nome;
+        existing.data.descrizione = marker.descrizione;
+        existing.data.lat = marker.lat;
+        existing.data.lng = marker.lng;
+        existing.marker.setLatLng([marker.lat, marker.lng]);
+        existing.marker.setPopupContent(createPopupContent(existing.data));
+      } else {
+        marker.id = data.id;
+        addMarker(marker);
+      }
+    })
+    .catch((err) => console.error(err));
+});
+
+function addMarker(marker) {
+  if (!marker.images) marker.images = [];
+  const leafletMarker = L.marker([marker.lat, marker.lng], { draggable: true }).addTo(map);
+  leafletMarker.bindPopup(createPopupContent(marker));
+  leafletMarker.on('popupopen', () => {
+    attachPopupEvents(marker, leafletMarker);
+  });
+  leafletMarker.on('dragend', () => {
+    const pos = leafletMarker.getLatLng();
+    marker.lat = pos.lat;
+    marker.lng = pos.lng;
+    saveMarker(marker);
+  });
+  markersById[marker.id] = { data: marker, marker: leafletMarker };
+}
+
+function attachPopupEvents(marker, leafletMarker) {
+  const popup = leafletMarker.getPopup().getElement();
+  popup.querySelector('.edit-marker').addEventListener('click', () => {
+    openModal(marker);
+  });
+  popup.querySelector('.delete-marker').addEventListener('click', () => {
+    if (confirm('Eliminare questo marker?')) {
+      fetch(`/markers/${marker.id}`, { method: 'DELETE' }).then((res) => {
+        if (res.ok) {
+          map.removeLayer(leafletMarker);
+          delete markersById[marker.id];
+        }
+      });
+    }
+  });
+  popup.querySelectorAll('.delete-image').forEach((btn) => {
+    const imageId = btn.dataset.imageId;
+    btn.addEventListener('click', () => {
+      if (confirm('Eliminare questa immagine?')) {
+        fetch(`/markers/${marker.id}/images/${imageId}`, { method: 'DELETE' }).then(
+          (res) => {
+            if (res.ok) {
+              marker.images = marker.images.filter(
+                (img) => String(img.id) !== String(imageId)
+              );
+              leafletMarker.setPopupContent(createPopupContent(marker));
+              leafletMarker.openPopup();
+            }
+          }
+        );
+      }
+    });
+  });
+}
+
+function openModal(marker) {
+  document.getElementById('markerId').value = marker.id || '';
+  document.getElementById('markerName').value = marker.nome || '';
+  document.getElementById('markerDesc').value = marker.descrizione || '';
+  document.getElementById('markerLat').value = marker.lat;
+  document.getElementById('markerLng').value = marker.lng;
+  modal.classList.add('show');
+}
+
+function saveMarker(marker) {
+  fetch(`/markers/${marker.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(marker),
+  }).catch((err) => console.error('Update failed', err));
+}
 
 function createPopupContent(marker) {
   let html = '';
@@ -34,9 +161,11 @@ function createPopupContent(marker) {
     html += '<div class="popup-images">';
     marker.images.forEach((img) => {
       const caption = img.didascalia ? `alt="${img.didascalia}"` : '';
-      html += `<img src="${img.url}" ${caption}>`;
+      html += `<div><img src="${img.url}" ${caption}/><button class="delete-image" data-image-id="${img.id}">Elimina immagine</button></div>`;
     });
     html += '</div>';
   }
+  html +=
+    '<button class="edit-marker">Modifica</button> <button class="delete-marker">Elimina</button>';
   return html;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,10 +20,62 @@
       display: block;
       margin-top: 4px;
     }
+    .modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.5);
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+    .modal.show {
+      display: flex;
+    }
+    .modal-content {
+      background: #fff;
+      padding: 1rem;
+      max-width: 400px;
+      width: 100%;
+    }
+    .modal-content label {
+      display: block;
+      margin-top: 0.5rem;
+    }
   </style>
 </head>
 <body>
   <div id="map"></div>
+  <div id="markerModal" class="modal">
+    <div class="modal-content">
+      <h2 id="modalTitle">Marker</h2>
+      <form id="markerForm">
+        <input type="hidden" id="markerId" />
+        <label>
+          Nome:
+          <input type="text" id="markerName" />
+        </label>
+        <label>
+          Descrizione:
+          <textarea id="markerDesc"></textarea>
+        </label>
+        <label>
+          Latitudine:
+          <input type="number" step="any" id="markerLat" />
+        </label>
+        <label>
+          Longitudine:
+          <input type="number" step="any" id="markerLng" />
+        </label>
+        <div style="margin-top:1rem;">
+          <button type="submit">Salva</button>
+          <button type="button" id="cancelModal">Annulla</button>
+        </div>
+      </form>
+    </div>
+  </div>
   <script
     src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-o9N1j7kP5ZSk+ieT1pO9MY+rF1rPe/nj1gGUU9SLE0k="


### PR DESCRIPTION
## Summary
- add modal to create or update markers
- enable drag and drop marker editing
- allow deleting markers and images with confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e5ddefdc4832793ae6720f0d11a8f