### PR TITLE
Serve frontend from root path

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,9 +8,17 @@ const auditLogsRouter = require('./auditLogs');
 const app = express();
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+// Serve the static frontend files
+const frontendPath = path.join(__dirname, '..', 'frontend');
+app.use(express.static(frontendPath));
 app.use('/auth', authRouter);
 app.use('/markers', markersRouter);
 app.use('/audit-logs', auditLogsRouter);
+
+// Return the frontend for the root path
+app.get('/', (req, res) => {
+  res.sendFile(path.join(frontendPath, 'index.html'));
+});
 
 app.get('/admin', authenticateToken, authorizeRole('admin'), (req, res) => {
   res.json({ message: 'Welcome admin!' });


### PR DESCRIPTION
## Summary
- serve static frontend files from backend
- handle `/` requests by sending `index.html`

## Testing
- `npm test`
- `curl -I localhost:3000`
- `curl localhost:3000 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e656ae5fc83279a2fa09e14e80d78