### PR TITLE
feat(frontend): add google maps tile option

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,8 @@
 
 Contiene il codice per l'interfaccia utente dell'applicazione.
 
-La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap e recupera i marker dal backend tramite `GET /markers`. Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
+La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap e recupera i marker dal backend tramite `GET /markers`. 
+È possibile usare le tile di Google Maps aggiungendo `?map=google` all'URL (es. `index.html?map=google`). Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
 
 Per testare l'interfaccia:
 1. avviare il server nella cartella `backend` (`npm start`);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,10 +1,28 @@
 const map = L.map('map').setView([0, 0], 2);
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 19,
-  attribution:
-    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-}).addTo(map);
+// Allow choosing the map provider via query parameter ?map=google
+const params = new URLSearchParams(window.location.search);
+const provider = params.get('map') === 'google' ? 'google' : 'osm';
+
+const tileProviders = {
+  osm: {
+    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    options: {
+      maxZoom: 19,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    },
+  },
+  google: {
+    url: 'https://{s}.google.com/vt?lyrs=m&x={x}&y={y}&z={z}',
+    options: {
+      maxZoom: 20,
+      subdomains: ['mt0', 'mt1', 'mt2', 'mt3'],
+    },
+  },
+};
+
+L.tileLayer(tileProviders[provider].url, tileProviders[provider].options).addTo(map);
 
 const markersById = {};
 const modal = document.getElementById('markerModal');


### PR DESCRIPTION
## Summary
- allow switching between OpenStreetMap and Google Maps tiles via `?map=google`
- document how to use the Google Maps option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f52b570108327967867b9d56b2f31