### PR TITLE
Add map provider toggle for OSM and Google Maps

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,7 +2,7 @@ const map = L.map('map').setView([0, 0], 2);
 
 // Allow choosing the map provider via query parameter ?map=google
 const params = new URLSearchParams(window.location.search);
-const provider = params.get('map') === 'google' ? 'google' : 'osm';
+let provider = params.get('map') === 'google' ? 'google' : 'osm';
 
 const tileProviders = {
   osm: {
@@ -22,7 +22,23 @@ const tileProviders = {
   },
 };
 
-L.tileLayer(tileProviders[provider].url, tileProviders[provider].options).addTo(map);
+let tileLayer = L.tileLayer(
+  tileProviders[provider].url,
+  tileProviders[provider].options
+).addTo(map);
+
+const mapSelect = document.getElementById('mapSelect');
+if (mapSelect) {
+  mapSelect.value = provider;
+  mapSelect.addEventListener('change', (e) => {
+    provider = e.target.value;
+    map.removeLayer(tileLayer);
+    tileLayer = L.tileLayer(
+      tileProviders[provider].url,
+      tileProviders[provider].options
+    ).addTo(map);
+  });
+}
 
 const markersById = {};
 const modal = document.getElementById('markerModal');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,9 +44,25 @@
       display: block;
       margin-top: 0.5rem;
     }
+    #mapTypeControl {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      z-index: 1000;
+      background: #fff;
+      padding: 0.5rem;
+      border-radius: 4px;
+    }
   </style>
 </head>
 <body>
+  <div id="mapTypeControl">
+    <label for="mapSelect">Map:</label>
+    <select id="mapSelect">
+      <option value="osm">OpenStreetMap</option>
+      <option value="google">Google Maps</option>
+    </select>
+  </div>
   <div id="map"></div>
   <div id="markerModal" class="modal">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- add UI selector to toggle between OpenStreetMap and Google Maps
- switch tile layers dynamically when map type changes

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688f564a47208327a9e0d56a7b8df40f