### PR TITLE
feat: add satellite map toggle

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,8 +2,7 @@
 
 Contiene il codice per l'interfaccia utente dell'applicazione.
 
-La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap e recupera i marker dal backend tramite `GET /markers`. 
-È possibile usare le tile di Google Maps aggiungendo `?map=google` all'URL (es. `index.html?map=google`). Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
+La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap per la mappa standard e le immagini satellitari di Esri per la vista satellite. Un pulsante consente di passare da una vista all'altra. Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
 
 Per testare l'interfaccia:
 1. avviare il server nella cartella `backend` (`npm start`);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,11 +1,9 @@
 const map = L.map('map').setView([0, 0], 2);
 
-// Allow choosing the map provider via query parameter ?map=google
-const params = new URLSearchParams(window.location.search);
-let provider = params.get('map') === 'google' ? 'google' : 'osm';
+let provider = 'satellite';
 
 const tileProviders = {
-  osm: {
+  standard: {
     url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     options: {
       maxZoom: 19,
@@ -13,11 +11,13 @@ const tileProviders = {
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
   },
-  google: {
-    url: 'https://{s}.google.com/vt?lyrs=m&x={x}&y={y}&z={z}',
+  satellite: {
+    url:
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     options: {
-      maxZoom: 20,
-      subdomains: ['mt0', 'mt1', 'mt2', 'mt3'],
+      maxZoom: 19,
+      attribution:
+        'Tiles © Esri — Source: Esri, Earthstar Geographics, NGA, USGS, GEBCO, DeLorme, NAVTEQ, and others',
     },
   },
 };
@@ -27,16 +27,19 @@ let tileLayer = L.tileLayer(
   tileProviders[provider].options
 ).addTo(map);
 
-const mapSelect = document.getElementById('mapSelect');
-if (mapSelect) {
-  mapSelect.value = provider;
-  mapSelect.addEventListener('change', (e) => {
-    provider = e.target.value;
+const mapToggle = document.getElementById('mapToggle');
+if (mapToggle) {
+  mapToggle.textContent =
+    provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
+  mapToggle.addEventListener('click', () => {
+    provider = provider === 'satellite' ? 'standard' : 'satellite';
     map.removeLayer(tileLayer);
     tileLayer = L.tileLayer(
       tileProviders[provider].url,
       tileProviders[provider].options
     ).addTo(map);
+    mapToggle.textContent =
+      provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
   });
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -57,11 +57,7 @@
 </head>
 <body>
   <div id="mapTypeControl">
-    <label for="mapSelect">Map:</label>
-    <select id="mapSelect">
-      <option value="osm">OpenStreetMap</option>
-      <option value="google">Google Maps</option>
-    </select>
+    <button id="mapToggle">Mappa standard</button>
   </div>
   <div id="map"></div>
   <div id="markerModal" class="modal">


### PR DESCRIPTION
## Summary
- default to free satellite imagery and allow toggling to standard OpenStreetMap tiles
- document map toggle in frontend README

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_688f58095d0c8327a28596e2f97ed60c