### PR TITLE
Overlay roads and labels on satellite map

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 Contiene il codice per l'interfaccia utente dell'applicazione.
 
-La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap per la mappa standard e le immagini satellitari di Esri per la vista satellite. Un pulsante consente di passare da una vista all'altra. Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
+La pagina `index.html` utilizza [Leaflet](https://leafletjs.com/) con le tile di OpenStreetMap per la mappa standard e le immagini satellitari di Esri per la vista satellite. Nella vista satellitare vengono sovrapposte strade e nomi dei luoghi grazie ai layer di riferimento di Esri. Un pulsante consente di passare da una vista all'altra. Ogni marker visualizza un pop-up con nome, descrizione e immagini associate.
 
 Per testare l'interfaccia:
 1. avviare il server nella cartella `backend` (`npm start`);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,29 +3,46 @@ const map = L.map('map').setView([0, 0], 2);
 let provider = 'satellite';
 
 const tileProviders = {
-  standard: {
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    options: {
-      maxZoom: 19,
-      attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  standard: [
+    {
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      options: {
+        maxZoom: 19,
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      },
     },
-  },
-  satellite: {
-    url:
-      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-    options: {
-      maxZoom: 19,
-      attribution:
-        'Tiles © Esri — Source: Esri, Earthstar Geographics, NGA, USGS, GEBCO, DeLorme, NAVTEQ, and others',
+  ],
+  satellite: [
+    {
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      options: {
+        maxZoom: 19,
+        attribution:
+          'Tiles © Esri — Source: Esri, Earthstar Geographics, NGA, USGS, GEBCO, DeLorme, NAVTEQ, and others',
+      },
     },
-  },
+    {
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
+      options: { maxZoom: 19 },
+    },
+    {
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}',
+      options: { maxZoom: 19 },
+    },
+  ],
 };
 
-let tileLayer = L.tileLayer(
-  tileProviders[provider].url,
-  tileProviders[provider].options
-).addTo(map);
+let tileLayers = [];
+
+function setProviderLayers() {
+  tileLayers.forEach((layer) => map.removeLayer(layer));
+  tileLayers = tileProviders[provider].map((p) =>
+    L.tileLayer(p.url, p.options).addTo(map)
+  );
+}
+
+setProviderLayers();
 
 const mapToggle = document.getElementById('mapToggle');
 if (mapToggle) {
@@ -33,11 +50,7 @@ if (mapToggle) {
     provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
   mapToggle.addEventListener('click', () => {
     provider = provider === 'satellite' ? 'standard' : 'satellite';
-    map.removeLayer(tileLayer);
-    tileLayer = L.tileLayer(
-      tileProviders[provider].url,
-      tileProviders[provider].options
-    ).addTo(map);
+    setProviderLayers();
     mapToggle.textContent =
       provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
   });


### PR DESCRIPTION
## Summary
- show roads and place labels on satellite view by layering Esri reference tiles
- handle multiple tile layers and toggle between map types
- document the new satellite view with roads/labels

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f59731e2c8327804cdb1fe6274db4