### PR TITLE
Fix scroll wheel zoom after map model switch

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -38,8 +38,16 @@ let tileLayers = [];
 function setProviderLayers() {
   tileLayers.forEach((layer) => map.removeLayer(layer));
   tileLayers = tileProviders[provider].map((p) =>
-    L.tileLayer(p.url, p.options).addTo(map)
+    L.tileLayer(p.url, {
+      updateWhenIdle: false,
+      updateWhenZooming: true,
+      ...p.options,
+    }).addTo(map)
   );
+  // Ensure scroll zoom remains active after switching provider
+  map.scrollWheelZoom.enable();
+  // Force a refresh so overlay elements update immediately
+  map.invalidateSize();
 }
 
 setProviderLayers();


### PR DESCRIPTION
## Summary
- Ensure switching map provider preserves scroll-wheel zoom
- Refresh map overlay immediately and allow tiles to update during zoom for a smoother experience

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f5b83f50083279bf8d67586b837fa