### PR TITLE
Fix overlay z-index so markers and menus display correctly

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,8 @@
     #map {
       height: 100vh;
       width: 100%;
+      position: relative;
+      z-index: 0;
     }
     .popup-images img {
       max-width: 100%;
@@ -30,6 +32,7 @@
       display: none;
       align-items: center;
       justify-content: center;
+      z-index: 2000;
     }
     .modal.show {
       display: flex;
@@ -48,10 +51,15 @@
       position: absolute;
       top: 10px;
       right: 10px;
-      z-index: 1000;
+      z-index: 2001;
       background: #fff;
       padding: 0.5rem;
       border-radius: 4px;
+    }
+    /* Ensure Leaflet markers and popups appear above the tile layers */
+    .leaflet-marker-pane,
+    .leaflet-popup-pane {
+      z-index: 2001;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- ensure Leaflet map container has baseline z-index
- raise z-index for modal, controls and marker/popup panes so they appear above the map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f5b9637708327b605690b90a15445