### PR TITLE
Ensure map fits viewport without scrollbars

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,5 +1,10 @@
 const map = L.map('map').setView([0, 0], 2);
 
+// Ensure the map resizes with the browser window
+window.addEventListener('resize', () => {
+  map.invalidateSize();
+});
+
 let provider = 'satellite';
 
 const tileProviders = {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,8 +11,13 @@
     crossorigin="anonymous"
   />
   <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+    }
     #map {
-      height: 100vh;
+      height: 100%;
       width: 100%;
     }
     .popup-images img {


### PR DESCRIPTION
## Summary
- Prevent page scrollbars and make map fill entire viewport
- Recalculate Leaflet map size on window resize

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f5bf6bb38832792925c18271b7d8d