### PR TITLE
Add top navigation with login and search

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>What About Us</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>About Us</h1>
+  <p>Informazioni sul progetto e sul team.</p>
+  <p><a href="index.html">Torna alla mappa</a></p>
+</body>
+</html>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -69,6 +69,78 @@ if (mapToggle) {
   });
 }
 
+// Login modal handling
+const loginLink = document.getElementById('loginLink');
+const loginModal = document.getElementById('loginModal');
+const loginForm = document.getElementById('loginForm');
+if (loginLink && loginModal && loginForm) {
+  loginLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    loginModal.classList.add('show');
+  });
+  document.getElementById('cancelLogin').addEventListener('click', () => {
+    loginModal.classList.remove('show');
+  });
+  loginForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const username = document.getElementById('loginUser').value;
+    const password = document.getElementById('loginPass').value;
+    fetch('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('Login failed');
+        }
+        return res.json();
+      })
+      .then((data) => {
+        localStorage.setItem('token', data.token);
+        loginModal.classList.remove('show');
+      })
+      .catch(() => alert('Login fallito'));
+  });
+}
+
+// Search functionality
+const searchBtn = document.getElementById('searchBtn');
+const searchInput = document.getElementById('searchInput');
+function handleSearch() {
+  const query = searchInput.value.trim();
+  if (!query) return;
+  const coordMatch = query.match(/^(-?\d+(?:\.\d+)?)[,\s]+(-?\d+(?:\.\d+)?)$/);
+  if (coordMatch) {
+    const lat = parseFloat(coordMatch[1]);
+    const lng = parseFloat(coordMatch[2]);
+    map.setView([lat, lng], 15);
+    L.marker([lat, lng]).addTo(map);
+  } else {
+    fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`)
+      .then((res) => res.json())
+      .then((results) => {
+        if (results && results.length) {
+          const lat = parseFloat(results[0].lat);
+          const lng = parseFloat(results[0].lon);
+          map.setView([lat, lng], 15);
+        } else {
+          alert('Nessun risultato trovato');
+        }
+      })
+      .catch(() => alert('Errore di ricerca'));
+  }
+}
+if (searchBtn && searchInput) {
+  searchBtn.addEventListener('click', handleSearch);
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSearch();
+    }
+  });
+}
+
 const markersById = {};
 const modal = document.getElementById('markerModal');
 const form = document.getElementById('markerForm');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,11 +16,24 @@
       margin: 0;
       overflow: hidden;
     }
+    #topMenu {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: #fff;
+      z-index: 2002;
+      padding: 0.5rem;
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+    }
     #map {
-      height: 100%;
+      height: calc(100% - 50px);
       width: 100%;
       position: relative;
       z-index: 0;
+      margin-top: 50px;
     }
     .popup-images img {
       max-width: 100%;
@@ -54,7 +67,7 @@
     }
     #mapTypeControl {
       position: absolute;
-      top: 10px;
+      top: 60px;
       right: 10px;
       z-index: 2001;
       background: #fff;
@@ -69,6 +82,12 @@
   </style>
 </head>
 <body>
+  <nav id="topMenu">
+    <a href="#" id="loginLink">Login</a>
+    <a href="about.html">What About Us</a>
+    <input type="text" id="searchInput" placeholder="Cerca via o coordinata" />
+    <button id="searchBtn">Cerca</button>
+  </nav>
   <div id="mapTypeControl">
     <button id="mapToggle">Mappa standard</button>
   </div>
@@ -97,6 +116,25 @@
         <div style="margin-top:1rem;">
           <button type="submit">Salva</button>
           <button type="button" id="cancelModal">Annulla</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div id="loginModal" class="modal">
+    <div class="modal-content">
+      <h2>Login</h2>
+      <form id="loginForm">
+        <label>
+          Username:
+          <input type="text" id="loginUser" required />
+        </label>
+        <label>
+          Password:
+          <input type="password" id="loginPass" required />
+        </label>
+        <div style="margin-top:1rem;">
+          <button type="submit">Accedi</button>
+          <button type="button" id="cancelLogin">Annulla</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Add fixed top menu with login, About Us link, and location search
- Implement login modal and Nominatim-based search
- Create simple About page

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688f99286ee08327a342c32471033c85