### PR TITLE
feat: use Esri hybrid basemap

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,73 +1,20 @@
-const map = L.map('map').setView([0, 0], 2);
+const imagery = L.esri.basemapLayer('Imagery');
+const labels = L.esri.basemapLayer('ImageryLabels');
+const hybrid = L.layerGroup([imagery, labels]);
+const standard = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap',
+  maxZoom: 19
+});
+const map = L.map('map', { layers: [hybrid] }).setView([45.4642, 9.1900], 13);
+L.control.layers({
+  'Hybrid (sat+etichette)': hybrid,
+  'Stradale (OSM)': standard
+}).addTo(map);
 
 // Ensure the map resizes with the browser window
 window.addEventListener('resize', () => {
   map.invalidateSize();
 });
-
-let provider = 'satellite';
-
-const tileProviders = {
-  standard: [
-    {
-      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      options: {
-        maxZoom: 19,
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-      },
-    },
-  ],
-  satellite: [
-    {
-      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-      options: {
-        maxZoom: 19,
-        attribution:
-          'Tiles © Esri — Source: Esri, Earthstar Geographics, NGA, USGS, GEBCO, DeLorme, NAVTEQ, and others',
-      },
-    },
-    {
-      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
-      options: { maxZoom: 19 },
-    },
-    {
-      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}',
-      options: { maxZoom: 19 },
-    },
-  ],
-};
-
-let tileLayers = [];
-
-function setProviderLayers() {
-  tileLayers.forEach((layer) => map.removeLayer(layer));
-  tileLayers = tileProviders[provider].map((p) =>
-    L.tileLayer(p.url, {
-      updateWhenIdle: false,
-      updateWhenZooming: true,
-      ...p.options,
-    }).addTo(map)
-  );
-  // Ensure scroll zoom remains active after switching provider
-  map.scrollWheelZoom.enable();
-  // Force a refresh so overlay elements update immediately
-  map.invalidateSize();
-}
-
-setProviderLayers();
-
-const mapToggle = document.getElementById('mapToggle');
-if (mapToggle) {
-  mapToggle.textContent =
-    provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
-  mapToggle.addEventListener('click', () => {
-    provider = provider === 'satellite' ? 'standard' : 'satellite';
-    setProviderLayers();
-    mapToggle.textContent =
-      provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
-  });
-}
 
 // Login modal handling
 const loginLink = document.getElementById('loginLink');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,15 +65,6 @@
       display: block;
       margin-top: 0.5rem;
     }
-    #mapTypeControl {
-      position: absolute;
-      top: 60px;
-      right: 10px;
-      z-index: 2001;
-      background: #fff;
-      padding: 0.5rem;
-      border-radius: 4px;
-    }
     /* Ensure Leaflet markers and popups appear above the tile layers */
     .leaflet-marker-pane,
     .leaflet-popup-pane {
@@ -88,9 +79,6 @@
     <input type="text" id="searchInput" placeholder="Cerca via o coordinata" />
     <button id="searchBtn">Cerca</button>
   </nav>
-  <div id="mapTypeControl">
-    <button id="mapToggle">Mappa standard</button>
-  </div>
   <div id="map"></div>
   <div id="markerModal" class="modal">
     <div class="modal-content">
@@ -145,6 +133,7 @@
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin="anonymous"
   ></script>
+  <script src="https://unpkg.com/esri-leaflet@3.0.16/dist/esri-leaflet.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Esri Leaflet and initialize map with hybrid imagery/label group
- offer layer control between Esri hybrid and OpenStreetMap standard
- remove custom satellite overlays and manual map toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd51435c8327b3a43b71b379d881