### PR TITLE
feat: modernize top menu

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -57,6 +57,20 @@ function setProviderLayers() {
 
 setProviderLayers();
 
+const menuButton = document.getElementById('menuButton');
+const menuDropdown = document.getElementById('menuDropdown');
+if (menuButton && menuDropdown) {
+  menuButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    menuDropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (!menuDropdown.contains(e.target)) {
+      menuDropdown.classList.remove('show');
+    }
+  });
+}
+
 const mapToggle = document.getElementById('mapToggle');
 if (mapToggle) {
   mapToggle.textContent =
@@ -66,6 +80,9 @@ if (mapToggle) {
     setProviderLayers();
     mapToggle.textContent =
       provider === 'satellite' ? 'Mappa standard' : 'Vista satellite';
+    if (menuDropdown) {
+      menuDropdown.classList.remove('show');
+    }
   });
 }
 
@@ -77,6 +94,9 @@ if (loginLink && loginModal && loginForm) {
   loginLink.addEventListener('click', (e) => {
     e.preventDefault();
     loginModal.classList.add('show');
+    if (menuDropdown) {
+      menuDropdown.classList.remove('show');
+    }
   });
   document.getElementById('cancelLogin').addEventListener('click', () => {
     loginModal.classList.remove('show');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,30 +10,88 @@
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin="anonymous"
   />
+  <link
+    href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    rel="stylesheet"
+  />
   <style>
     html, body {
       height: 100%;
       margin: 0;
       overflow: hidden;
     }
-    #topMenu {
+    #topBar {
       position: fixed;
       top: 0;
       left: 0;
       right: 0;
-      background: #fff;
+      height: 56px;
+      background: #6200ee;
+      color: #fff;
       z-index: 2002;
-      padding: 0.5rem;
       display: flex;
-      gap: 1rem;
       align-items: center;
+      padding: 0 1rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+    #searchInput {
+      flex: 1;
+      padding: 0.5rem;
+      border: none;
+      border-radius: 4px;
+      margin-right: 0.5rem;
+    }
+    #searchBtn {
+      background: #fff;
+      color: #6200ee;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-right: 0.5rem;
+    }
+    #menuButton {
+      cursor: pointer;
+      user-select: none;
+    }
+    #menuDropdown {
+      position: absolute;
+      top: 56px;
+      right: 1rem;
+      background: #fff;
+      color: #333;
+      border-radius: 4px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      display: none;
+      flex-direction: column;
+      min-width: 160px;
+      z-index: 2003;
+    }
+    #menuDropdown.show {
+      display: flex;
+    }
+    #menuDropdown a,
+    #menuDropdown button {
+      background: none;
+      border: none;
+      padding: 0.75rem 1rem;
+      text-align: left;
+      width: 100%;
+      cursor: pointer;
+      font: inherit;
+      color: inherit;
+      text-decoration: none;
+    }
+    #menuDropdown a:hover,
+    #menuDropdown button:hover {
+      background: #f0f0f0;
     }
     #map {
-      height: calc(100% - 50px);
+      height: calc(100% - 56px);
       width: 100%;
       position: relative;
       z-index: 0;
-      margin-top: 50px;
+      margin-top: 56px;
     }
     .popup-images img {
       max-width: 100%;
@@ -65,15 +123,6 @@
       display: block;
       margin-top: 0.5rem;
     }
-    #mapTypeControl {
-      position: absolute;
-      top: 60px;
-      right: 10px;
-      z-index: 2001;
-      background: #fff;
-      padding: 0.5rem;
-      border-radius: 4px;
-    }
     /* Ensure Leaflet markers and popups appear above the tile layers */
     .leaflet-marker-pane,
     .leaflet-popup-pane {
@@ -82,15 +131,16 @@
   </style>
 </head>
 <body>
-  <nav id="topMenu">
-    <a href="#" id="loginLink">Login</a>
-    <a href="about.html">What About Us</a>
+  <nav id="topBar">
     <input type="text" id="searchInput" placeholder="Cerca via o coordinata" />
     <button id="searchBtn">Cerca</button>
+    <span id="menuButton" class="material-icons">more_vert</span>
+    <div id="menuDropdown">
+      <button id="mapToggle">Mappa standard</button>
+      <a href="about.html">What About Us</a>
+      <a href="#" id="loginLink">Login</a>
+    </div>
   </nav>
-  <div id="mapTypeControl">
-    <button id="mapToggle">Mappa standard</button>
-  </div>
   <div id="map"></div>
   <div id="markerModal" class="modal">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- redesign top navigation with Material-style three-dot menu
- move map type switch into dropdown and remove floating control
- add dropdown handling and close menu on login or switch

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688f9ac9c4a483278e7351b28227d087