### PR TITLE
feat: make map caching optional via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Applicazione web che consente agli utenti di segnalare la posizione di una BTS t
 
 - Per cambiare la porta del server è possibile usare la variabile d'ambiente `PORT`.
 - Se si dispone di un bucket S3, impostare le variabili `S3_BUCKET`, `AWS_ACCESS_KEY_ID` e `AWS_SECRET_ACCESS_KEY` per salvare le immagini nel cloud; in caso contrario verranno salvate localmente nella cartella `backend/uploads`.
+- Impostare `ENABLE_MAP_CACHE=true` per abilitare il download periodico dell'estratto OSM dell'Italia; la funzione è disabilitata di default.
 
 ## Struttura del progetto
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,4 +16,4 @@ Il database SQLite inizializza automaticamente le seguenti tabelle:
 
 ## Aggiornamento automatico della mappa OSM
 
-Lo script `npm run update-map` scarica l'estratto OpenStreetMap dell'Italia e lo salva nella cartella `map-data/`. Il processo verifica quotidianamente la disponibilità di nuove versioni e sostituisce automaticamente il file se necessario.
+Per motivi di performance il caching dell'estratto OpenStreetMap è disattivato di default. È possibile attivarlo impostando la variabile d'ambiente `ENABLE_MAP_CACHE=true` prima di avviare il server: in tal caso lo script `scripts/update-map.js` scarica l'estratto dell'Italia nella cartella `map-data/` e ne verifica quotidianamente eventuali aggiornamenti.

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  enableMapCache: process.env.ENABLE_MAP_CACHE === 'true'
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const authRouter = require('./auth');
 const { authenticateToken, authorizeRole } = require('./middleware/auth');
 const markersRouter = require('./markers');
 const auditLogsRouter = require('./auditLogs');
+const config = require('./config');
 
 const app = express();
 app.use(express.json());
@@ -14,6 +15,10 @@ app.use(express.static(frontendPath));
 app.use('/auth', authRouter);
 app.use('/markers', markersRouter);
 app.use('/audit-logs', auditLogsRouter);
+
+if (config.enableMapCache) {
+  require('./scripts/update-map');
+}
 
 // Return the frontend for the root path
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- allow server to toggle periodic map downloads via `ENABLE_MAP_CACHE`
- document optional map caching and new configuration flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68907164bfcc8327aba9a20707c842db