### PR TITLE
feat: make database path configurable and standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Applicazione web che consente agli utenti di segnalare la posizione di una BTS t
 - Per cambiare la porta del server è possibile usare la variabile d'ambiente `PORT`.
 - Impostare `UPLOADS_DIR` per specificare la cartella in cui salvare le immagini (di default `backend/uploads`).
 - Impostare `ENABLE_MAP_CACHE=true` per abilitare il download periodico dell'estratto OSM dell'Italia; la funzione è disabilitata di default.
+- Impostare `DB_DIR` per specificare una cartella esterna in cui salvare il database SQLite.
+
+## Database standalone
+
+Per eseguire il database come processo indipendente, utile per mantenerlo attivo durante gli aggiornamenti del frontend o del backend, è disponibile lo script:
+
+```bash
+npm run db
+```
+
+Il database verrà creato nella cartella indicata da `DB_DIR` o, in mancanza, in `backend/`.
 
 ## Struttura del progetto
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,8 @@ Il database SQLite inizializza automaticamente le seguenti tabelle:
 ## Aggiornamento automatico della mappa OSM
 
 Per motivi di performance il caching dell'estratto OpenStreetMap è disattivato di default. È possibile attivarlo impostando la variabile d'ambiente `ENABLE_MAP_CACHE=true` prima di avviare il server: in tal caso lo script `scripts/update-map.js` scarica l'estratto dell'Italia nella cartella `map-data/` e ne verifica quotidianamente eventuali aggiornamenti.
+
+## Configurazione del database
+
+- Impostare la variabile d'ambiente `DB_DIR` per utilizzare una cartella esterna dove salvare il file `data.sqlite`.
+- È possibile avviare il database come processo separato con `npm run db` nella cartella `backend`.

--- a/backend/config.js
+++ b/backend/config.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
   enableMapCache: process.env.ENABLE_MAP_CACHE === 'true',
   uploadsDir: process.env.UPLOADS_DIR || path.join(__dirname, 'uploads'),
+  dbDir: process.env.DB_DIR || __dirname,
   admin: {
     username: process.env.ADMIN_USERNAME || 'admin',
     password: process.env.ADMIN_PASSWORD || 'adminpass',

--- a/backend/db-server.js
+++ b/backend/db-server.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const config = require('./config');
+require('./db');
+
+console.log(`Database ready at ${path.join(config.dbDir, 'data.sqlite')}`);
+console.log('Database process running. Press Ctrl+C to stop.');
+
+setInterval(() => {}, 1 << 30);

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,7 +1,11 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const fs = require('fs');
+const config = require('./config');
 
-const db = new sqlite3.Database(path.join(__dirname, 'data.sqlite'));
+const dbPath = path.join(config.dbDir, 'data.sqlite');
+fs.mkdirSync(config.dbDir, { recursive: true });
+const db = new sqlite3.Database(dbPath);
 
 db.serialize(() => {
   db.run('PRAGMA foreign_keys = ON');

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "node -e \"console.log('No tests')\"",
-    "update-map": "node scripts/update-map.js"
+    "update-map": "node scripts/update-map.js",
+    "db": "node db-server.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",


### PR DESCRIPTION
## Summary
- add `DB_DIR` env var to configure SQLite location
- expose standalone DB process via `npm run db`
- document database options in READMEs

## Testing
- `cd backend && npm test`
- `npm run db`

------
https://chatgpt.com/codex/tasks/task_e_68909be44c9c8327b21d7892e5e8b7ef