### PR TITLE
Add map context menu for inserting markers

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11,6 +11,36 @@ L.control.layers({
   'Stradale (OSM)': standard
 }).addTo(map);
 
+// Context menu handling
+const mapContextMenu = document.getElementById('mapContextMenu');
+const insertMarkerBtn = document.getElementById('insertMarkerBtn');
+let savedLat, savedLng;
+
+map.on('contextmenu', (e) => {
+  e.originalEvent.preventDefault();
+  savedLat = e.latlng.lat;
+  savedLng = e.latlng.lng;
+  mapContextMenu.style.left = `${e.containerPoint.x}px`;
+  mapContextMenu.style.top = `${e.containerPoint.y}px`;
+  mapContextMenu.classList.add('show');
+});
+
+insertMarkerBtn.addEventListener('click', () => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    loginModal.classList.add('show');
+  } else {
+    openModal({ lat: savedLat, lng: savedLng, images: [] });
+  }
+  mapContextMenu.classList.remove('show');
+});
+
+document.addEventListener('click', (e) => {
+  if (mapContextMenu.classList.contains('show') && !mapContextMenu.contains(e.target)) {
+    mapContextMenu.classList.remove('show');
+  }
+});
+
 // Ensure the map resizes with the browser window
 window.addEventListener('resize', () => {
   map.invalidateSize();
@@ -178,6 +208,10 @@ fetch('/markers')
   });
 
 map.on('click', (e) => {
+  if (mapContextMenu.classList.contains('show')) {
+    mapContextMenu.classList.remove('show');
+    return;
+  }
   const token = localStorage.getItem('token');
   if (!token) {
     loginModal.classList.add('show');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -96,6 +96,28 @@
       width:100%;
       height:auto;
     }
+    #mapContextMenu {
+      position: absolute;
+      z-index: 2000;
+      background: #fff;
+      border: 1px solid #ccc;
+      display: none;
+    }
+    #mapContextMenu.show {
+      display: block;
+    }
+    #mapContextMenu button {
+      display: block;
+      width: 100%;
+      padding: 8px 12px;
+      border: none;
+      background: none;
+      text-align: left;
+      cursor: pointer;
+    }
+    #mapContextMenu button:hover {
+      background: #eee;
+    }
   </style>
 </head>
 <body>
@@ -120,6 +142,7 @@
     </nav>
   </div>
   <div id="map"></div>
+  <div id="mapContextMenu"><button id="insertMarkerBtn">Inserisci marker</button></div>
   <div id="markerModal" class="modal">
     <div class="modal-content">
       <h2 id="modalTitle">Marker</h2>


### PR DESCRIPTION
## Summary
- add hidden context menu with “Inserisci marker” option
- wire up Leaflet context menu to open the marker modal
- close context menu on outside clicks or when opening modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68909f5bb6c4832791e93fac91d80e94