### PR TITLE
feat: make database path configurable and standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Applicazione web che consente agli utenti di segnalare la posizione di una BTS t
 - Per cambiare la porta del server è possibile usare la variabile d'ambiente `PORT`.
 - Impostare `UPLOADS_DIR` per specificare la cartella in cui salvare le immagini (di default `backend/uploads`).
 - Impostare `ENABLE_MAP_CACHE=true` per abilitare il download periodico dell'estratto OSM dell'Italia; la funzione è disabilitata di default.
+- Impostare `DB_DIR` per specificare una cartella esterna in cui salvare il database SQLite.
+
+## Database standalone
+
+Per eseguire il database come processo indipendente, utile per mantenerlo attivo durante gli aggiornamenti del frontend o del backend, è disponibile lo script:
+
+```bash
+npm run db
+```
+
+Il database verrà creato nella cartella indicata da `DB_DIR` o, in mancanza, in `backend/`.
 
 ## Struttura del progetto
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,8 @@ Il database SQLite inizializza automaticamente le seguenti tabelle:
 ## Aggiornamento automatico della mappa OSM
 
 Per motivi di performance il caching dell'estratto OpenStreetMap è disattivato di default. È possibile attivarlo impostando la variabile d'ambiente `ENABLE_MAP_CACHE=true` prima di avviare il server: in tal caso lo script `scripts/update-map.js` scarica l'estratto dell'Italia nella cartella `map-data/` e ne verifica quotidianamente eventuali aggiornamenti.
+
+## Configurazione del database
+
+- Impostare la variabile d'ambiente `DB_DIR` per utilizzare una cartella esterna dove salvare il file `data.sqlite`.
+- È possibile avviare il database come processo separato con `npm run db` nella cartella `backend`.

--- a/backend/auditLogs/index.js
+++ b/backend/auditLogs/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const db = require('../db');
+const { handleDbError } = require('../db-utils');
 const { authenticateToken, authorizeRole } = require('../middleware/auth');
 
 const router = express.Router();
@@ -7,7 +8,7 @@ const router = express.Router();
 router.get('/', authenticateToken, authorizeRole('admin'), (req, res) => {
   db.all('SELECT * FROM audit_logs ORDER BY timestamp DESC', [], (err, rows) => {
     if (err) {
-      return res.status(500).json({ error: 'DB error' });
+      return handleDbError(res, err);
     }
     res.json(rows);
   });

--- a/backend/config.js
+++ b/backend/config.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
   enableMapCache: process.env.ENABLE_MAP_CACHE === 'true',
   uploadsDir: process.env.UPLOADS_DIR || path.join(__dirname, 'uploads'),
+  dbDir: process.env.DB_DIR || __dirname,
   admin: {
     username: process.env.ADMIN_USERNAME || 'admin',
     password: process.env.ADMIN_PASSWORD || 'adminpass',

--- a/backend/db-server.js
+++ b/backend/db-server.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const config = require('./config');
+require('./db');
+
+console.log(`Database ready at ${path.join(config.dbDir, 'data.sqlite')}`);
+console.log('Database process running. Press Ctrl+C to stop.');
+
+setInterval(() => {}, 1 << 30);

--- a/backend/db-utils.js
+++ b/backend/db-utils.js
@@ -1,0 +1,6 @@
+function handleDbError(res, err, message = 'DB error') {
+  console.error(message, err);
+  return res.status(500).json({ error: message });
+}
+
+module.exports = { handleDbError };

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,7 +1,17 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const fs = require('fs');
+const config = require('./config');
 
-const db = new sqlite3.Database(path.join(__dirname, 'data.sqlite'));
+const dbPath = path.join(config.dbDir, 'data.sqlite');
+fs.mkdirSync(config.dbDir, { recursive: true });
+const db = new sqlite3.Database(dbPath, (err) => {
+  if (err) {
+    console.error(`Failed to connect to database at ${dbPath}:`, err);
+  } else {
+    console.log(`Connected to database at ${dbPath}`);
+  }
+});
 
 db.serialize(() => {
   db.run('PRAGMA foreign_keys = ON');

--- a/backend/markers/index.js
+++ b/backend/markers/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const multer = require('multer');
 const config = require('../config');
 const db = require('../db');
+const { handleDbError } = require('../db-utils');
 const { authenticateToken, authorizeRoles } = require('../middleware/auth');
 const { logMarkerAction } = require('../middleware/audit');
 
@@ -45,10 +46,10 @@ function validateMarkerInput(req, res, next) {
 router.get('/', (req, res) => {
   const sql = `SELECT m.*, mi.id as image_id, mi.url, mi.didascalia
                FROM markers m LEFT JOIN marker_images mi ON m.id = mi.marker_id`;
-  db.all(sql, [], (err, rows) => {
-    if (err) {
-      return res.status(500).json({ error: 'DB error' });
-    }
+    db.all(sql, [], (err, rows) => {
+      if (err) {
+        return handleDbError(res, err);
+      }
     const markers = {};
     rows.forEach((row) => {
       if (!markers[row.id]) {
@@ -81,10 +82,10 @@ router.get('/:id', (req, res) => {
   const sql = `SELECT m.*, mi.id as image_id, mi.url, mi.didascalia
                FROM markers m LEFT JOIN marker_images mi ON m.id = mi.marker_id
                WHERE m.id = ?`;
-  db.all(sql, [id], (err, rows) => {
-    if (err) {
-      return res.status(500).json({ error: 'DB error' });
-    }
+    db.all(sql, [id], (err, rows) => {
+      if (err) {
+        return handleDbError(res, err);
+      }
     if (rows.length === 0) {
       return res.status(404).json({ error: 'Not found' });
     }
@@ -119,13 +120,13 @@ router.post(
   validateMarkerInput,
   (req, res, next) => {
     const { lat, lng, descrizione, images, nome, autore, color } = req.body;
-    db.run(
-      'INSERT INTO markers (lat, lng, descrizione, nome, autore, color) VALUES (?, ?, ?, ?, ?, ?)',
-      [lat, lng, descrizione || null, nome || null, autore || null, color || null],
-      function (err) {
-        if (err) {
-          return res.status(500).json({ error: 'DB error' });
-        }
+      db.run(
+        'INSERT INTO markers (lat, lng, descrizione, nome, autore, color) VALUES (?, ?, ?, ?, ?, ?)',
+        [lat, lng, descrizione || null, nome || null, autore || null, color || null],
+        function (err) {
+          if (err) {
+            return handleDbError(res, err);
+          }
         const markerId = this.lastID;
         if (images && images.length) {
           const stmt = db.prepare(
@@ -134,10 +135,10 @@ router.post(
           for (const img of images) {
             stmt.run(markerId, img.url, img.didascalia || null);
           }
-          stmt.finalize((err2) => {
-            if (err2) {
-              return res.status(500).json({ error: 'DB error' });
-            }
+            stmt.finalize((err2) => {
+              if (err2) {
+                return handleDbError(res, err2);
+              }
             res.locals.markerId = markerId;
             res.status(201).json({ id: markerId });
             next();
@@ -161,17 +162,17 @@ router.put(
   (req, res, next) => {
     const { lat, lng, descrizione, images, nome, autore, color } = req.body;
     const id = req.params.id;
-    db.run(
-      'UPDATE markers SET lat = ?, lng = ?, descrizione = ?, nome = ?, autore = ?, color = ? WHERE id = ?',
-      [lat, lng, descrizione || null, nome || null, autore || null, color || null, id],
-      function (err) {
-        if (err) {
-          return res.status(500).json({ error: 'DB error' });
-        }
-        db.run('DELETE FROM marker_images WHERE marker_id = ?', [id], (err2) => {
-          if (err2) {
-            return res.status(500).json({ error: 'DB error' });
+      db.run(
+        'UPDATE markers SET lat = ?, lng = ?, descrizione = ?, nome = ?, autore = ?, color = ? WHERE id = ?',
+        [lat, lng, descrizione || null, nome || null, autore || null, color || null, id],
+        function (err) {
+          if (err) {
+            return handleDbError(res, err);
           }
+          db.run('DELETE FROM marker_images WHERE marker_id = ?', [id], (err2) => {
+            if (err2) {
+              return handleDbError(res, err2);
+            }
           if (images && images.length) {
             const stmt = db.prepare(
               'INSERT INTO marker_images (marker_id, url, didascalia) VALUES (?, ?, ?)'
@@ -179,10 +180,10 @@ router.put(
             for (const img of images) {
               stmt.run(id, img.url, img.didascalia || null);
             }
-            stmt.finalize((err3) => {
-              if (err3) {
-                return res.status(500).json({ error: 'DB error' });
-              }
+              stmt.finalize((err3) => {
+                if (err3) {
+                  return handleDbError(res, err3);
+                }
               res.locals.markerId = id;
               res.json({ id });
               next();
@@ -212,26 +213,27 @@ router.post(
       return res.status(400).json({ error: 'Image file is required' });
     }
     const saveUrl = (url) => {
-      db.run(
-        'INSERT INTO marker_images (marker_id, url, didascalia) VALUES (?, ?, ?)',
-        [markerId, url, didascalia],
-        function (err) {
-          if (err) {
-            return res.status(500).json({ error: 'DB error' });
+        db.run(
+          'INSERT INTO marker_images (marker_id, url, didascalia) VALUES (?, ?, ?)',
+          [markerId, url, didascalia],
+          function (err) {
+            if (err) {
+              return handleDbError(res, err);
+            }
+            res.status(201).json({ id: this.lastID, url });
           }
-          res.status(201).json({ id: this.lastID, url });
-        }
-      );
+        );
     };
     const uploadsDir = config.uploadsDir;
     fs.mkdirSync(uploadsDir, { recursive: true });
     const filename = `${Date.now()}_${file.originalname}`;
-    fs.writeFile(path.join(uploadsDir, filename), file.buffer, (err) => {
-      if (err) {
-        return res.status(500).json({ error: 'Upload error' });
-      }
-      saveUrl(`/uploads/${filename}`);
-    });
+      fs.writeFile(path.join(uploadsDir, filename), file.buffer, (err) => {
+        if (err) {
+          console.error('Upload error', err);
+          return res.status(500).json({ error: 'Upload error' });
+        }
+        saveUrl(`/uploads/${filename}`);
+      });
   }
 );
 
@@ -241,23 +243,23 @@ router.delete(
   authorizeRoles('admin', 'editor'),
   (req, res) => {
     const { markerId, imageId } = req.params;
-    db.get(
-      'SELECT url FROM marker_images WHERE id = ? AND marker_id = ?',
-      [imageId, markerId],
-      (err, row) => {
-        if (err) {
-          return res.status(500).json({ error: 'DB error' });
-        }
+      db.get(
+        'SELECT url FROM marker_images WHERE id = ? AND marker_id = ?',
+        [imageId, markerId],
+        (err, row) => {
+          if (err) {
+            return handleDbError(res, err);
+          }
         if (!row) {
           return res.status(404).json({ error: 'Not found' });
         }
-        db.run(
-          'DELETE FROM marker_images WHERE id = ?',
-          [imageId],
-          (err2) => {
-            if (err2) {
-              return res.status(500).json({ error: 'DB error' });
-            }
+          db.run(
+            'DELETE FROM marker_images WHERE id = ?',
+            [imageId],
+            (err2) => {
+              if (err2) {
+                return handleDbError(res, err2);
+              }
             const filePath = path.join(
               config.uploadsDir,
               path.basename(row.url)
@@ -280,7 +282,7 @@ router.delete(
     const id = req.params.id;
     db.run('DELETE FROM markers WHERE id = ?', [id], function (err) {
       if (err) {
-        return res.status(500).json({ error: 'DB error' });
+        return handleDbError(res, err);
       }
       if (this.changes === 0) {
         return res.status(404).json({ error: 'Not found' });

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "node -e \"console.log('No tests')\"",
-    "update-map": "node scripts/update-map.js"
+    "update-map": "node scripts/update-map.js",
+    "db": "node db-server.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",


### PR DESCRIPTION
## Summary
- add `DB_DIR` env var to configure SQLite location
- expose standalone DB process via `npm run db`
- log database errors for easier debugging

## Testing
- `cd backend && npm test`
- `npm run db`


------
https://chatgpt.com/codex/tasks/task_e_68909be44c9c8327b21d7892e5e8b7ef