### PR TITLE
Fix marker saving with configurable storage paths

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,9 +1,7 @@
-const path = require('path');
-
 module.exports = {
   enableMapCache: process.env.ENABLE_MAP_CACHE === 'true',
-  uploadsDir: '/opt/myapp/media',
-  dbDir: '/opt/myapp/database',
+  uploadsDir: process.env.UPLOADS_DIR || '/opt/media',
+  dbDir: process.env.DB_DIR || '/opt/database',
   admin: {
     username: process.env.ADMIN_USERNAME || 'admin',
     password: process.env.ADMIN_PASSWORD || 'adminpass',


### PR DESCRIPTION
## Summary
- Default uploads directory to `/opt/media` and database directory to `/opt/database`, still allowing environment variable overrides.

## Testing
- `npm test`
- Manual `curl` login and marker creation

------
https://chatgpt.com/codex/tasks/task_e_6890ac4cbd4483279ce229bf5322bf1e