### PR TITLE
Fix marker deletion failure caused by audit log FK

### DIFF
--- a/backend/middleware/audit.js
+++ b/backend/middleware/audit.js
@@ -3,7 +3,7 @@ const db = require('../db');
 function logMarkerAction(action) {
   return (req, res, next) => {
     const userId = req.user ? req.user.id : null;
-    const markerId = res.locals.markerId || req.params.id;
+    const markerId = action === 'delete' ? null : res.locals.markerId || req.params.id;
     db.run(
       'INSERT INTO audit_logs (user_id, action, marker_id) VALUES (?, ?, ?)',
       [userId, action, markerId],


### PR DESCRIPTION
## Summary
- Clear audit log references and delete markers without foreign key errors
- Skip audit log marker reference when deleting markers to prevent constraint violations

## Testing
- `npm test`
- `curl -i -X DELETE http://localhost:3000/markers/1 -H 'Authorization: Bearer <token>'`
- `curl -s http://localhost:3000/markers`


------
https://chatgpt.com/codex/tasks/task_e_6890b00585e08327967860dd14f1d62f