### PR TITLE
feat: add configurable tags for markers

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -33,11 +33,13 @@ db.serialize(() => {
     descrizione TEXT,
     autore TEXT,
     color TEXT,
+    tag TEXT,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
   )`);
 
   // Ensure legacy databases have the new columns
   db.run('ALTER TABLE markers ADD COLUMN color TEXT', () => {});
+  db.run('ALTER TABLE markers ADD COLUMN tag TEXT', () => {});
 
   db.run(`CREATE TABLE IF NOT EXISTS marker_images (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ const markersRouter = require('./markers');
 const auditLogsRouter = require('./auditLogs');
 const usersRouter = require('./users');
 const config = require('./config');
+const tags = require('./tags');
 const db = require('./db');
 const bcrypt = require('bcrypt');
 
@@ -19,6 +20,9 @@ app.use('/auth', authRouter);
 app.use('/markers', markersRouter);
 app.use('/audit-logs', auditLogsRouter);
 app.use('/users', usersRouter);
+app.get('/tags', (req, res) => {
+  res.json(tags);
+});
 
 if (config.enableMapCache) {
   require('./scripts/update-map');

--- a/backend/tag-config.json
+++ b/backend/tag-config.json
@@ -1,0 +1,6 @@
+[
+  "LTE/5G",
+  "Radio TV",
+  "Wisp Eolo",
+  "Unknown"
+]

--- a/backend/tags.js
+++ b/backend/tags.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const tagsPath = path.join(__dirname, 'tag-config.json');
+let tags = ["LTE/5G", "Radio TV", "Wisp Eolo", "Unknown"];
+
+try {
+  const data = fs.readFileSync(tagsPath, 'utf-8');
+  const parsed = JSON.parse(data);
+  if (Array.isArray(parsed)) {
+    tags = parsed;
+  }
+} catch (err) {
+  // use default tags if file missing or invalid
+}
+
+module.exports = tags;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -82,6 +82,10 @@
     nav .nav-wrapper .search-container button {
       margin-left: 10px;
     }
+    nav .nav-wrapper .search-container .tag-filter-field {
+      width: 180px;
+      margin-left: 10px;
+    }
     nav .nav-wrapper ul {
       margin-left: auto;
     }
@@ -131,6 +135,11 @@
             <label for="searchInput">Cerca via o coordinata</label>
           </div>
           <button id="searchBtn" class="btn waves-effect">Cerca</button>
+          <div class="tag-filter-field">
+            <select id="tagFilter">
+              <option value="">Tutti i tag</option>
+            </select>
+          </div>
         </div>
         <ul>
           <li><a href="#" id="loginLink">Login</a></li>
@@ -167,6 +176,12 @@
         <label>
           Colore Pin:
           <input type="color" id="markerColor" />
+        </label>
+        <label>
+          Tag:
+          <select id="markerTag">
+            <option value="">Seleziona un tag</option>
+          </select>
         </label>
         <label>
           Immagini:


### PR DESCRIPTION
## Summary
- add tag column to marker model and implement API filtering
- expose tags from configuration via `/tags`
- allow frontend to assign and filter markers by tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890b3c17d0c83278113b2a9dbad4e54