### PR TITLE
Disable left-click marker creation

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -245,17 +245,10 @@ fetch('/markers')
     console.error('Failed to load markers', err);
   });
 
-map.on('click', (e) => {
+map.on('click', () => {
   if (mapContextMenu.classList.contains('show')) {
     mapContextMenu.classList.remove('show');
-    return;
   }
-  const token = localStorage.getItem('token');
-  if (!token) {
-    loginModal.classList.add('show');
-    return;
-  }
-  openModal({ lat: e.latlng.lat, lng: e.latlng.lng, images: [] });
 });
 
 document.getElementById('cancelModal').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Remove left-click map handler that opened marker creation modal
- Left-click now only closes the context menu; markers added via right-click menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890f0fb80248327b4dba802729bda8f