### PR TITLE
Fix map top panel and move layer selector to bottom left

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,7 +9,7 @@ const map = L.map('map', { layers: [hybrid] }).setView([45.4642, 9.1900], 13);
 L.control.layers({
   'Hybrid (sat+etichette)': hybrid,
   'Stradale (OSM)': standard
-}).addTo(map);
+}, null, { position: 'bottomleft' }).addTo(map);
 
 // Context menu handling
 const mapContextMenu = document.getElementById('mapContextMenu');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,11 +26,11 @@
       overflow: hidden;
     }
     #map {
-      height: calc(100% - 80px);
+      position: absolute;
+      top: 64px;
+      bottom: 0;
       width: 100%;
-      position: relative;
       z-index: 0;
-      margin-top: 80px;
     }
     .modal {
       position: fixed;


### PR DESCRIPTION
## Summary
- prevent top whitespace when map is first moved by positioning the map container absolutely beneath the navbar
- place map layer selector in the bottom-left corner

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890f427ea108327966bb06b5aa9a4be