### PR TITLE
Enable multiple tags per marker

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -184,9 +184,7 @@
         </label>
         <label>
           Tag:
-          <select id="markerTag">
-            <option value="">Seleziona un tag</option>
-          </select>
+          <div id="markerTags"></div>
         </label>
         <label>
           Immagini:
@@ -225,6 +223,7 @@
     <div class="modal-content" style="max-width:600px;width:100%;height:90%;overflow:auto;">
       <h4 id="viewTitle"></h4>
       <p id="viewDesc"></p>
+      <p id="viewTags"></p>
       <div id="viewCarousel" class="carousel"></div>
       <div id="viewActions" style="margin-top:1rem;"></div>
     </div>


### PR DESCRIPTION
## Summary
- Support array-based tags in markers API and database, allowing multiple tags on each marker
- Replace single tag selector with checkbox list on the map UI and persist selected tags
- Show and filter markers by any selected tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891c3b9ed348327968b2ddae79d7412