### PR TITLE
Use vertical layout for marker modals

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -144,14 +144,15 @@
       border-radius: 0;
       padding: 0;
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
     }
     #viewMarkerModal .carousel.carousel-slider {
-      width: 50%;
-      height: 100%;
+      width: 100%;
+      height: 50%;
     }
     #viewMarkerModal .view-info {
-      width: 50%;
+      width: 100%;
+      flex: 1;
       overflow: auto;
       padding: 1rem;
     }
@@ -164,6 +165,8 @@
       height: 100%;
       max-width: none;
       border-radius: 0;
+      display: flex;
+      flex-direction: column;
       overflow: auto;
     }
   </style>


### PR DESCRIPTION
## Summary
- Switch marker view modal layout from horizontal split to vertical stack
- Ensure marker edit modal uses column layout for better mobile experience

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891db18292c8327b2f2af7d7961a6e0