### PR TITLE
feat(frontend): add image navigation arrows

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -472,12 +472,16 @@ function openMarkerView(marker, leafletMarker) {
   document.getElementById('viewDesc').textContent = marker.descrizione || '';
   document.getElementById('viewTags').textContent = (marker.tags || []).join(', ');
   const carousel = document.getElementById('viewCarousel');
+  const prevBtn = document.getElementById('carouselPrev');
+  const nextBtn = document.getElementById('carouselNext');
   const existing = M.Carousel.getInstance(carousel);
   if (existing) {
     existing.destroy();
   }
   carousel.innerHTML = '';
   const images = (marker.images || []).slice(0, 10);
+  prevBtn.style.display = 'none';
+  nextBtn.style.display = 'none';
   if (images.length) {
     images.forEach((img) => {
       const item = document.createElement('a');
@@ -492,10 +496,16 @@ function openMarkerView(marker, leafletMarker) {
       }
       carousel.appendChild(item);
     });
-    M.Carousel.init(carousel, { fullWidth: true, indicators: true });
+    const instance = M.Carousel.init(carousel, { fullWidth: true, indicators: true });
     carousel.querySelectorAll('img').forEach((img) => {
       img.addEventListener('click', () => img.classList.toggle('enlarged'));
     });
+    if (images.length > 1) {
+      prevBtn.style.display = 'flex';
+      nextBtn.style.display = 'flex';
+      prevBtn.onclick = () => instance.prev();
+      nextBtn.onclick = () => instance.next();
+    }
   }
   const actions = document.getElementById('viewActions');
   actions.innerHTML = '';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,6 +110,31 @@
     #viewCarousel .carousel-item img.enlarged {
       transform: scale(1.2);
     }
+    .carousel-container {
+      position: relative;
+    }
+    .carousel-container .carousel-nav {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      background: rgba(0,0,0,0.5);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      z-index: 2;
+    }
+    .carousel-container .carousel-nav.left {
+      left: 10px;
+    }
+    .carousel-container .carousel-nav.right {
+      right: 10px;
+    }
     #mapContextMenu {
       position: absolute;
       z-index: 2000;
@@ -255,17 +280,25 @@
       </form>
     </div>
   </div>
-  <div id="viewMarkerModal" class="modal">
-    <div class="modal-content">
-      <div id="viewCarousel" class="carousel carousel-slider"></div>
-      <div class="view-info">
-        <h4 id="viewTitle"></h4>
-        <p id="viewDesc"></p>
-        <p id="viewTags"></p>
-        <div id="viewActions" style="margin-top:1rem;"></div>
+    <div id="viewMarkerModal" class="modal">
+      <div class="modal-content">
+        <div class="carousel-container">
+          <button id="carouselPrev" class="carousel-nav left">
+            <i class="material-icons">chevron_left</i>
+          </button>
+          <div id="viewCarousel" class="carousel carousel-slider"></div>
+          <button id="carouselNext" class="carousel-nav right">
+            <i class="material-icons">chevron_right</i>
+          </button>
+        </div>
+        <div class="view-info">
+          <h4 id="viewTitle"></h4>
+          <p id="viewDesc"></p>
+          <p id="viewTags"></p>
+          <div id="viewActions" style="margin-top:1rem;"></div>
+        </div>
       </div>
     </div>
-  </div>
   <div id="resetModal" class="modal">
     <div class="modal-content">
       <h2>Reset Password</h2>


### PR DESCRIPTION
## Summary
- add left/right navigation arrows for marker image carousel
- wire up carousel controls in JavaScript

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891dd61a9e08327a43b6a9ce7d8692b