### PR TITLE
Fix marker carousel failing to reload images

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -492,10 +492,6 @@ function openMarkerView(marker, leafletMarker) {
       }
       carousel.appendChild(item);
     });
-    M.Carousel.init(carousel, { fullWidth: true, indicators: true });
-    carousel.querySelectorAll('img').forEach((img) => {
-      img.addEventListener('click', () => img.classList.toggle('enlarged'));
-    });
   }
   const actions = document.getElementById('viewActions');
   actions.innerHTML = '';
@@ -536,23 +532,29 @@ function openMarkerView(marker, leafletMarker) {
   }
   markerViewModal.classList.add('show');
 
-  carousel.querySelectorAll('.delete-image').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const imageId = btn.dataset.imageId;
-      if (confirm('Eliminare questa immagine?')) {
-        fetch(`/markers/${marker.id}/images/${imageId}`, {
-          method: 'DELETE',
-          headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
-        }).then((res) => {
-          if (res.ok) {
-            marker.images = marker.images.filter((img) => String(img.id) !== String(imageId));
-            markerViewModal.classList.remove('show');
-            openMarkerView(marker, leafletMarker);
-          }
-        });
-      }
+  if (images.length) {
+    M.Carousel.init(carousel, { fullWidth: true, indicators: true });
+    carousel.querySelectorAll('img').forEach((img) => {
+      img.addEventListener('click', () => img.classList.toggle('enlarged'));
     });
-  });
+    carousel.querySelectorAll('.delete-image').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const imageId = btn.dataset.imageId;
+        if (confirm('Eliminare questa immagine?')) {
+          fetch(`/markers/${marker.id}/images/${imageId}`, {
+            method: 'DELETE',
+            headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+          }).then((res) => {
+            if (res.ok) {
+              marker.images = marker.images.filter((img) => String(img.id) !== String(imageId));
+              markerViewModal.classList.remove('show');
+              openMarkerView(marker, leafletMarker);
+            }
+          });
+        }
+      });
+    });
+  }
 }
 
 markerViewModal.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Ensure marker view modal is shown before initializing the image carousel so images load every time the modal opens

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6891ef80fe0883278e6ccdb8305007ca