### PR TITLE
fix: show full marker images

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -534,9 +534,6 @@ function openMarkerView(marker, leafletMarker) {
 
   if (images.length) {
     M.Carousel.init(carousel, { fullWidth: true, indicators: true });
-    carousel.querySelectorAll('img').forEach((img) => {
-      img.addEventListener('click', () => img.classList.toggle('enlarged'));
-    });
     carousel.querySelectorAll('.delete-image').forEach((btn) => {
       btn.addEventListener('click', () => {
         const imageId = btn.dataset.imageId;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -103,12 +103,8 @@
     }
     #viewCarousel .carousel-item img {
       width: 100%;
-      height: auto;
-      cursor: pointer;
-      transition: transform 0.3s ease;
-    }
-    #viewCarousel .carousel-item img.enlarged {
-      transform: scale(1.2);
+      height: 100%;
+      object-fit: contain;
     }
     #mapContextMenu {
       position: absolute;


### PR DESCRIPTION
## Summary
- ensure marker images fit their container without cropping
- remove zoom-on-click effect for marker images

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891f330f3988327bb44b2fd6361a6c6