### PR TITLE
Fix multi-tag marker gradient rendering

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -458,7 +458,13 @@ function createTagIcon(tags) {
   const segments = colors
     .map((c, i) => `${c} ${i * step}% ${(i + 1) * step}%`)
     .join(', ');
-  const style = `background: conic-gradient(${segments}); -webkit-background-clip: text; background-clip: text; color: transparent;`;
+  const style =
+    `background: conic-gradient(${segments});` +
+    ' -webkit-background-clip: text;' +
+    ' background-clip: text;' +
+    ' color: transparent;' +
+    ' -webkit-text-fill-color: transparent;' +
+    ' text-shadow: none;';
   return L.divIcon({
     className: 'custom-pin',
     html: `<i class="material-icons" style="${style}">place</i>`,


### PR DESCRIPTION
## Summary
- ensure markers with multiple tags render a conic gradient icon
- prevent white icons by disabling shadow and filling icon via `-webkit-text-fill-color: transparent`

## Testing
- `npm test` (in backend)

------
https://chatgpt.com/codex/tasks/task_e_6891ff186aac8327bbe25061f9e53c21