### PR TITLE
Fix: disable dragging of placed markers

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -345,18 +345,12 @@ form.addEventListener('submit', (e) => {
 function addMarker(marker) {
   if (!marker.images) marker.images = [];
   const leafletMarker = L.marker([marker.lat, marker.lng], {
-    draggable: currentUserRole === 'admin' || currentUserRole === 'editor',
+    draggable: false,
     icon: createTagIcon(marker.tags),
   });
   markerClusters.addLayer(leafletMarker);
   leafletMarker.on('click', () => {
     openMarkerView(marker, leafletMarker);
-  });
-  leafletMarker.on('dragend', () => {
-    const pos = leafletMarker.getLatLng();
-    marker.lat = pos.lat;
-    marker.lng = pos.lng;
-    saveMarker(marker);
   });
   markersById[marker.id] = { data: marker, marker: leafletMarker };
   applyTagFilter();


### PR DESCRIPTION
## Summary
- markers are now created as non-draggable, removing the ability for admins to reposition them after placement

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892035b0f7c832796090430d4194ba7