### PR TITLE
feat: add per-tag details for markers

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -36,6 +36,7 @@ db.serialize(() => {
     tag TEXT,
     localita TEXT,
     frequenze TEXT,
+    tag_details TEXT,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
   )`);
 
@@ -44,6 +45,7 @@ db.serialize(() => {
   db.run('ALTER TABLE markers ADD COLUMN tag TEXT', () => {});
   db.run('ALTER TABLE markers ADD COLUMN localita TEXT', () => {});
   db.run('ALTER TABLE markers ADD COLUMN frequenze TEXT', () => {});
+  db.run('ALTER TABLE markers ADD COLUMN tag_details TEXT', () => {});
 
   db.run(`CREATE TABLE IF NOT EXISTS marker_images (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -321,9 +321,9 @@
           <input type="hidden" id="markerId" />
           <label> Nome: <input type="text" id="markerName" />
           </label>
-          <label> Descrizione: <textarea id="markerDesc"></textarea>
+          <label id="markerDescLabel"> Descrizione: <textarea id="markerDesc"></textarea>
           </label>
-          <label> Frequenze / Tecnologie: <input type="text" id="markerFreq" />
+          <label id="markerFreqLabel"> Frequenze / Tecnologie: <input type="text" id="markerFreq" />
           </label>
           <label> Latitudine: <input type="number" step="any" id="markerLat" />
           </label>
@@ -331,6 +331,10 @@
           </label>
           <label> Tag: <div id="markerTags"></div>
           </label>
+          <div id="tagTabsContainer" style="display:none">
+            <ul id="tagTabs" class="tabs"></ul>
+            <div id="tagTabContents"></div>
+          </div>
           <label> Immagini: <input type="file" id="markerImages" accept="image/*" multiple />
           </label>
           <div id="existingImages" style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-top:0.5rem;"></div>
@@ -364,6 +368,10 @@
         <div id="viewCarousel" class="carousel carousel-slider"></div>
         <div class="view-info">
           <h4 id="viewTitle"></h4>
+          <div id="viewTagTabsContainer" style="display:none">
+            <ul id="viewTagTabs" class="tabs"></ul>
+            <div id="viewTagContents"></div>
+          </div>
           <p id="viewDesc"></p>
           <p id="viewFreq"></p>
           <p id="viewLocalita"></p>


### PR DESCRIPTION
## Summary
- support per-tag details on markers in API and database
- render tag-specific tabs when editing markers with multiple tags
- show tag information in tabbed view for markers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ececb5408327a8a65df903016a8b