### PR TITLE
Fix copying tag details when adding additional tags

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -343,11 +343,15 @@ function renderTagInputs() {
         frequenze: freqEl ? freqEl.value : '',
       };
     });
-  } else if (selected.length === 1) {
-    editingTagDetails[selected[0]] = {
-      descrizione: document.getElementById('markerDesc').value,
-      frequenze: document.getElementById('markerFreq').value,
-    };
+  } else {
+    const descVal = document.getElementById('markerDesc').value;
+    const freqVal = document.getElementById('markerFreq').value;
+    selected.forEach((tag) => {
+      editingTagDetails[tag] = {
+        descrizione: descVal,
+        frequenze: freqVal,
+      };
+    });
   }
 
   const sourceTag = selected.find((t) => editingTagDetails[t]);


### PR DESCRIPTION
## Summary
- Ensure description and frequency fields copy to all selected tags when switching from a single tag to multiple tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fdf6817c83279f023e21e286f690