### PR TITLE
refactor: use merge-nearby helper in import scripts

### DIFF
--- a/backend/scripts/import-aria-veneto.js
+++ b/backend/scripts/import-aria-veneto.js
@@ -1,7 +1,7 @@
 const xlsx = require('xlsx');
 const proj4 = require('proj4');
 const db = require('../db');
-const { findNearbyMarker, mergeTagData } = require('./utils');
+const { mergeNearby } = require('./merge-nearby');
 
 const SOURCE = 'ARIA Veneto';
 
@@ -128,24 +128,6 @@ async function main() {
     const tagsStr = tags.length ? JSON.stringify(tags) : null;
     const tagDetailsStr = JSON.stringify(tagDetails);
 
-    const existing = await findNearbyMarker(lat, lng, radiusMeters);
-    if (existing) {
-      const merged = mergeTagData(existing, tags, tagDetails);
-      try {
-        await runAsync(
-          'UPDATE markers SET tag = ?, tag_details = ? WHERE id = ?',
-          [JSON.stringify(merged.tags), JSON.stringify(merged.details), existing.id]
-        );
-        await runAsync(
-          'INSERT INTO audit_logs (user_id, action, marker_id) VALUES (?, ?, ?)',
-          [userId, 'update', existing.id]
-        );
-      } catch (err) {
-        console.error('DB update failed:', err.message);
-      }
-      continue;
-    }
-
     try {
       const result = await runAsync(
         'INSERT INTO markers (lat, lng, descrizione, nome, autore, tag, localita, frequenze, tag_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -160,6 +142,7 @@ async function main() {
     }
   }
 
+  await mergeNearby(radiusMeters);
   db.close();
 }
 

--- a/backend/scripts/import-arpat-toscana.js
+++ b/backend/scripts/import-arpat-toscana.js
@@ -1,7 +1,7 @@
 const xlsx = require('xlsx');
 const proj4 = require('proj4');
 const db = require('../db');
-const { findNearbyMarker, mergeTagData } = require('./utils');
+const { mergeNearby } = require('./merge-nearby');
 
 const SOURCE = 'ARPAT Toscana';
 
@@ -121,24 +121,6 @@ async function main() {
     const tagsStr = tags.length ? JSON.stringify(tags) : null;
     const tagDetailsStr = JSON.stringify(tagDetails);
 
-    const existing = await findNearbyMarker(lat, lng, radiusMeters);
-    if (existing) {
-      const merged = mergeTagData(existing, tags, tagDetails);
-      try {
-        await runAsync(
-          'UPDATE markers SET tag = ?, tag_details = ? WHERE id = ?',
-          [JSON.stringify(merged.tags), JSON.stringify(merged.details), existing.id]
-        );
-        await runAsync(
-          'INSERT INTO audit_logs (user_id, action, marker_id) VALUES (?, ?, ?)',
-          [userId, 'update', existing.id]
-        );
-      } catch (err) {
-        console.error('DB update failed:', err.message);
-      }
-      continue;
-    }
-
     try {
       const result = await runAsync(
         'INSERT INTO markers (lat, lng, descrizione, nome, autore, tag, localita, frequenze, tag_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -153,6 +135,7 @@ async function main() {
     }
   }
 
+  await mergeNearby(radiusMeters);
   db.close();
 }
 

--- a/backend/scripts/import-lteitaly.js
+++ b/backend/scripts/import-lteitaly.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 const db = require('../db');
-const { findNearbyMarker, mergeTagData } = require('./utils');
+const { mergeNearby } = require('./merge-nearby');
 
 const SOURCE = 'https://lteitaly.it';
 
@@ -93,47 +93,12 @@ async function main() {
     const tokens = parts[9].trim().split(/\s+/);
     const siteName = tokens.slice(3).join(' ');
 
-    const existing = await findNearbyMarker(lat, lng, radiusMeters);
-
     const nome = `${lat},${lng}`;
     const descrizione = `${siteName} | Provider:${provider}`;
     const tagsArr = ['LTE/5G'];
     const tagDetails = { 'LTE/5G': { descrizione, frequenze: null } };
     const tagsStr = JSON.stringify(tagsArr);
     const tagDetailsStr = JSON.stringify(tagDetails);
-
-    if (existing) {
-      const [basePart, provPart] = (existing.descrizione || '').split(' | Provider:');
-      const providers = provPart
-        ? provPart.split(',').map((p) => p.trim()).filter(Boolean)
-        : [];
-      if (providers.includes(provider)) continue;
-      const base = basePart && basePart.trim() ? basePart.trim() : siteName;
-      providers.push(provider);
-      const newDescrizione = `${base} | Provider:${providers.join(',')}`;
-      const merged = mergeTagData(existing, tagsArr, {
-        'LTE/5G': { descrizione: newDescrizione, frequenze: null },
-      });
-      try {
-        await runAsync(
-          'UPDATE markers SET descrizione = ?, tag = ?, tag_details = ? WHERE id = ?',
-          [
-            newDescrizione,
-            JSON.stringify(merged.tags),
-            JSON.stringify(merged.details),
-            existing.id,
-          ]
-        );
-        await runAsync(
-          'INSERT INTO audit_logs (user_id, action, marker_id) VALUES (?, ?, ?)',
-          [userId, 'update', existing.id]
-        );
-      } catch (err) {
-        console.error('DB update failed:', err.message);
-      }
-      continue;
-    }
-
     try {
       const result = await runAsync(
         'INSERT INTO markers (lat, lng, descrizione, nome, autore, tag, localita, frequenze, tag_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -148,6 +113,7 @@ async function main() {
     }
   }
 
+  await mergeNearby(radiusMeters);
   db.close();
 }
 

--- a/backend/scripts/merge-nearby.js
+++ b/backend/scripts/merge-nearby.js
@@ -6,12 +6,13 @@ const runAsync = promisify(db.run).bind(db);
 
 function haversine(lat1, lon1, lat2, lon2) {
   const R = 6371000;
-  const toRad = deg => deg * Math.PI / 180;
+  const toRad = (deg) => (deg * Math.PI) / 180;
   const dLat = toRad(lat2 - lat1);
   const dLon = toRad(lon2 - lon1);
-  const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-            Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
-            Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   return R * c;
 }
@@ -163,12 +164,7 @@ async function mergeMarkers(ids) {
   }
 }
 
-(async () => {
-  const dist = parseFloat(process.argv[2]);
-  if (isNaN(dist)) {
-    console.error('Usage: node scripts/merge-nearby.js <distance-meters>');
-    process.exit(1);
-  }
+async function mergeNearby(dist) {
   const markers = await allAsync('SELECT id, lat, lng FROM markers');
   const clusters = [];
   const used = new Set();
@@ -181,7 +177,7 @@ async function mergeMarkers(ids) {
       added = false;
       for (const n of markers) {
         if (used.has(n.id)) continue;
-        if (cluster.some(c => haversine(c.lat, c.lng, n.lat, n.lng) <= dist)) {
+        if (cluster.some((c) => haversine(c.lat, c.lng, n.lat, n.lng) <= dist)) {
           cluster.push(n);
           used.add(n.id);
           added = true;
@@ -189,7 +185,7 @@ async function mergeMarkers(ids) {
       }
     }
     if (cluster.length > 1) {
-      clusters.push(cluster.map(c => c.id));
+      clusters.push(cluster.map((c) => c.id));
     }
   }
   let merged = 0;
@@ -197,6 +193,20 @@ async function mergeMarkers(ids) {
     await mergeMarkers(ids);
     merged += ids.length - 1;
   }
-  console.log(`Uniti ${merged} marker`);
-  db.close();
-})();
+  return merged;
+}
+
+module.exports = { mergeNearby };
+
+if (require.main === module) {
+  (async () => {
+    const dist = parseFloat(process.argv[2]);
+    if (isNaN(dist)) {
+      console.error('Usage: node scripts/merge-nearby.js <distance-meters>');
+      process.exit(1);
+    }
+    const merged = await mergeNearby(dist);
+    console.log(`Uniti ${merged} marker`);
+    db.close();
+  })();
+}


### PR DESCRIPTION
## Summary
- refactor merge-nearby script into reusable helper
- invoke shared merge-nearby logic after imports to unify adjacent markers

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a322cc14388327ae492f24e0fa08b0