### PR TITLE
Enable multi-tag filtering on map

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -74,7 +74,7 @@ const tagsPromise = fetch('/tags')
       }
     });
     if (window.M && M.FormSelect && tagFilter) {
-      M.FormSelect.init(tagFilter);
+      M.FormSelect.init(tagFilter, { dropdownOptions: { closeOnClick: false } });
     }
   });
 
@@ -422,9 +422,16 @@ if (markerTagContainer) {
 }
 
 function applyTagFilter() {
-  const selected = tagFilter ? tagFilter.value : '';
+  const selected = tagFilter
+    ? Array.from(tagFilter.selectedOptions)
+        .map((o) => o.value)
+        .filter(Boolean)
+    : [];
   Object.values(markersById).forEach(({ data, marker }) => {
-    if (!selected || (data.tags && data.tags.includes(selected))) {
+    if (
+      selected.length === 0 ||
+      (data.tags && selected.some((s) => data.tags.includes(s)))
+    ) {
       if (!markerClusters.hasLayer(marker)) {
         markerClusters.addLayer(marker);
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -285,8 +285,8 @@
               </div>
               <button id="searchBtn" class="btn waves-effect">Cerca</button>
               <div class="tag-filter-field">
-                <select id="tagFilter">
-                  <option value="">Tutti i tag</option>
+                <select id="tagFilter" multiple>
+                  <option value="" disabled selected>Tutti i tag</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- allow selecting multiple tags to filter map markers
- keep tag filter dropdown open during multi-select

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6dc0995e08327bca13da69e5ac129