### PR TITLE
Add ARPA FVG import script

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bcrypt": "^5.1.0",
+        "csv-parse": "^5.5.0",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
         "multer": "^2.0.2",
@@ -545,6 +546,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "import-arpat-toscana": "node scripts/import-arpat-toscana.js",
     "import-aria-veneto": "node scripts/import-aria-veneto.js",
     "import-lteitaly": "node scripts/import-lteitaly.js",
-    "merge-nearby": "node scripts/merge-nearby.js"
+    "merge-nearby": "node scripts/merge-nearby.js",
+    "import-arpafvg": "node scripts/import-arpafvg.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",
@@ -21,6 +22,7 @@
     "nodemailer": "^6.9.1",
     "proj4": "^2.19.10",
     "sqlite3": "^5.1.6",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "csv-parse": "^5.5.0"
   }
 }

--- a/backend/scripts/import-arpafvg.js
+++ b/backend/scripts/import-arpafvg.js
@@ -1,0 +1,131 @@
+const fs = require('fs');
+const parse = require('csv-parse/sync');
+const proj4 = require('proj4');
+const db = require('../db');
+const { mergeNearby } = require('./merge-nearby');
+
+const SOURCE = 'ARPA FVG';
+
+function runAsync(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) reject(err);
+      else resolve({ lastID: this.lastID });
+    });
+  });
+}
+
+function getOrCreateUserId(username) {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT id FROM users WHERE username = ?', [username], (err, row) => {
+      if (err) return reject(err);
+      if (row) return resolve(row.id);
+      db.run(
+        'INSERT INTO users (username, role) VALUES (?, ?)',
+        [username, 'user'],
+        function (err2) {
+          if (err2) return reject(err2);
+          resolve(this.lastID);
+        }
+      );
+    });
+  });
+}
+
+function parseFloatSafe(value) {
+  if (value == null) return null;
+  const v = parseFloat(String(value).replace(',', '.'));
+  return Number.isNaN(v) ? null : v;
+}
+
+// ETRS89 / UTM zone 33N (EPSG:25833)
+const etrs89 = '+proj=utm +zone=33 +ellps=GRS80 +units=m +no_defs';
+
+function convertCoords(x, y) {
+  try {
+    const [lng, lat] = proj4(etrs89, proj4.WGS84, [x, y]);
+    return { lat, lng };
+  } catch (e) {
+    return { lat: null, lng: null };
+  }
+}
+
+function mapGestore(gestore) {
+  const g = (gestore || '').trim().toUpperCase();
+  if (g === 'RFI') return { tags: ['Sconosciuto'], descrizione: 'Rete ferroviaria' };
+  if (g === 'OPNET') return { tags: ['Opnet'], descrizione: 'Opnet' };
+  if (g === 'FASTWEB AIR') return { tags: ['WISP'], descrizione: 'Fastweb Air' };
+  if (g === '3LETTRONICA INDUSTRIALE') return null; // skip
+  return { tags: ['Sconosciuto'], descrizione: gestore || null };
+}
+
+async function main() {
+  const filePath = process.argv[2];
+  const radiusMeters = parseFloat(process.argv[3]) || 10;
+  if (!filePath) {
+    console.error('Usage: node scripts/import-arpafvg.js <file.csv> [radiusMeters=10]');
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const records = parse.parse(content, {
+    columns: true,
+    skip_empty_lines: true,
+  });
+
+  const userId = await getOrCreateUserId(SOURCE);
+
+  for (const row of records) {
+    const mapping = mapGestore(row['Gestore']);
+    if (!mapping) continue; // skip entry
+
+    const x = parseFloatSafe(row['Coord. X (ETRS89)']);
+    const y = parseFloatSafe(row['Coord. Y (ETRS89)']);
+    if (x == null || y == null) {
+      console.warn('Skipping row due to invalid coordinates');
+      continue;
+    }
+    const { lat, lng } = convertCoords(x, y);
+    if (lat == null || lng == null) {
+      console.warn('Skipping row due to failed coordinate conversion');
+      continue;
+    }
+
+    const nome = row['ID Sito'] || row['Codice Sito'] || row['feature_id'] || `${lat},${lng}`;
+    const localita = row['Comune'] || null;
+
+    let descrizione = mapping.descrizione;
+    const info = [];
+    if (row['Data Attivazione']) info.push(`Data attivazione: ${row['Data Attivazione']}`);
+    if (row['Quota s.l.m. (ETRS89)']) info.push(`Quota: ${row['Quota s.l.m. (ETRS89)']} m`);
+    if (info.length) {
+      descrizione = descrizione ? `${descrizione} | ${info.join(' | ')}` : info.join(' | ');
+    }
+
+    const tags = mapping.tags;
+    const tagDetails = {};
+    tags.forEach((t) => {
+      tagDetails[t] = { descrizione, frequenze: null };
+    });
+    const tagsStr = tags.length ? JSON.stringify(tags) : null;
+    const tagDetailsStr = JSON.stringify(tagDetails);
+
+    try {
+      const result = await runAsync(
+        'INSERT INTO markers (lat, lng, descrizione, nome, autore, tag, localita, frequenze, tag_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [lat, lng, descrizione, nome, SOURCE, tagsStr, localita, null, tagDetailsStr]
+      );
+      await runAsync(
+        'INSERT INTO audit_logs (user_id, action, marker_id) VALUES (?, ?, ?)',
+        [userId, 'create', result.lastID]
+      );
+    } catch (err) {
+      console.error('DB insert failed:', err.message);
+    }
+  }
+
+  await mergeNearby(radiusMeters);
+  db.close();
+}
+
+main();


### PR DESCRIPTION
## Summary
- add importer for ARPA FVG CSV datasets, mapping operator values to tags and descriptions
- expose importer via new npm script and include csv-parse dependency

## Testing
- `npm install`
- `npm test`
- `node scripts/import-arpafvg.js`


------
https://chatgpt.com/codex/tasks/task_e_68a861d4261c83279f4de94f7121fcc5