### PR TITLE
feat: add annotation mode for dataset creation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const authRouter = require('./auth');
 const { authenticateToken, authorizeRole } = require('./middleware/auth');
 const markersRouter = require('./markers');
@@ -11,7 +12,7 @@ const db = require('./db');
 const bcrypt = require('bcrypt');
 
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: '10mb' }));
 app.use('/uploads', express.static(config.uploadsDir));
 // Serve the static frontend files
 const frontendPath = path.join(__dirname, '..', 'frontend');
@@ -22,6 +23,26 @@ app.use('/audit-logs', auditLogsRouter);
 app.use('/users', usersRouter);
 app.get('/tags', (req, res) => {
   res.json(loadTags());
+});
+
+const annotationsDir = path.join(__dirname, '..', 'data', 'annotations');
+fs.mkdirSync(annotationsDir, { recursive: true });
+
+app.post('/annotate', (req, res) => {
+  const { image, bbox } = req.body || {};
+  if (!image || !bbox) {
+    return res.status(400).json({ error: 'Missing data' });
+  }
+  const match = image.match(/^data:image\/png;base64,(.+)$/);
+  if (!match) {
+    return res.status(400).json({ error: 'Invalid image data' });
+  }
+  const buffer = Buffer.from(match[1], 'base64');
+  const base = `annotation-${Date.now()}`;
+  fs.writeFileSync(path.join(annotationsDir, `${base}.png`), buffer);
+  const line = `0 ${bbox.x} ${bbox.y} ${bbox.w} ${bbox.h}`;
+  fs.writeFileSync(path.join(annotationsDir, `${base}.txt`), line);
+  res.json({ status: 'ok' });
 });
 
 app.put('/tags', authenticateToken, authorizeRole('admin'), (req, res) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,23 @@
         z-index: 0;
       }
 
+      #annotationOverlay {
+        position: absolute;
+        top: 64px;
+        bottom: 0;
+        width: 100%;
+        display: none;
+        cursor: crosshair;
+        z-index: 1000;
+      }
+
+      .annotation-rect {
+        position: absolute;
+        border: 2px dashed red;
+        background: rgba(255, 0, 0, 0.2);
+        pointer-events: none;
+      }
+
       .modal {
         position: fixed;
         top: 0;
@@ -823,6 +840,9 @@
               <a href="#" id="mergeSelectedBtn" style="display:none">Unisci selezionati</a>
             </li>
             <li>
+              <a href="#" id="annotationModeBtn">Annotatore</a>
+            </li>
+            <li>
               <a href="about.html">About</a>
             </li>
           </ul>
@@ -830,6 +850,7 @@
       </nav>
     </div>
     <div id="map"></div>
+    <div id="annotationOverlay"></div>
     <div id="mapContextMenu">
       <button id="insertMarkerBtn">Inserisci marker</button>
     </div>
@@ -1092,6 +1113,7 @@
     <script src="https://unpkg.com/esri-leaflet@3.0.16/dist/esri-leaflet.js"></script>
     <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="app.js"></script>
 
     <script>


### PR DESCRIPTION
## Summary
- allow users to draw bounding boxes on the map and capture screenshots
- save screenshot and YOLO annotation on the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa04d7a66883279c768afb9315fb83