### PR TITLE
Enable CORS for map tiles and screenshots

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,9 +1,10 @@
-const imagery = L.esri.basemapLayer('Imagery');
-const labels = L.esri.basemapLayer('ImageryLabels');
+const imagery = L.esri.basemapLayer('Imagery', { crossOrigin: 'anonymous' });
+const labels = L.esri.basemapLayer('ImageryLabels', { crossOrigin: 'anonymous' });
 const hybrid = L.layerGroup([imagery, labels]);
 const standard = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '&copy; OpenStreetMap',
-  maxZoom: 19
+  maxZoom: 19,
+  crossOrigin: 'anonymous'
 });
 const map = L.map('map', { layers: [hybrid] }).setView([45.4642, 9.1900], 13);
 L.control.layers({
@@ -927,7 +928,7 @@ if (annotationModeBtn && annotationOverlay) {
     const y = parseInt(annotationRect.style.top);
     const w = parseInt(annotationRect.style.width);
     const h = parseInt(annotationRect.style.height);
-    const canvas = await html2canvas(document.getElementById('map'));
+    const canvas = await html2canvas(document.getElementById('map'), { useCORS: true });
     const dataUrl = canvas.toDataURL('image/png');
     const imgW = canvas.width;
     const imgH = canvas.height;


### PR DESCRIPTION
## Summary
- Specify `crossOrigin: 'anonymous'` on Esri basemap and OpenStreetMap tile layers
- Allow html2canvas to fetch tiles via CORS when capturing the map

## Testing
- `npm test`
- `curl -I https://tile.openstreetmap.org/0/0/0.png`
- `curl -I https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/0/0/0`


------
https://chatgpt.com/codex/tasks/task_e_68aa0807fb888327bd822d533769ff3b