### PR TITLE
Add welcome page and temporary password email

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -46,6 +46,10 @@ app.get('/admin', authenticateToken, authorizeRole('admin'), (req, res) => {
   res.sendFile(path.join(frontendPath, 'admin.html'));
 });
 
+app.get('/welcome', (req, res) => {
+  res.sendFile(path.join(frontendPath, 'welcome.html'));
+});
+
 async function ensureAdmin() {
   const { username, password, email } = config.admin;
   db.get('SELECT id FROM users WHERE username = ?', [username], async (err, row) => {

--- a/backend/users/index.js
+++ b/backend/users/index.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+const nodemailer = require('nodemailer');
 const db = require('../db');
+const config = require('../config');
 const { authenticateToken, authorizeRole } = require('../middleware/auth');
 
 const router = express.Router();
@@ -15,17 +18,35 @@ router.get('/', (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  const { username, password, email, role } = req.body;
-  if (!username || !password || !email) {
+  const { username, email, role } = req.body;
+  if (!username || !email) {
     return res.status(400).json({ error: 'Missing fields' });
   }
   try {
-    const hashed = await bcrypt.hash(password, 10);
+    const tempPassword = crypto.randomBytes(8).toString('hex');
+    const hashed = await bcrypt.hash(tempPassword, 10);
     db.run(
       'INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)',
       [username, email, hashed, role || 'user'],
       function (err) {
         if (err) return res.status(500).json({ error: 'User exists' });
+
+        const transporter = nodemailer.createTransport({
+          service: 'gmail',
+          auth: {
+            user: config.smtp.user,
+            pass: config.smtp.pass,
+          },
+        });
+
+        const welcomeUrl = `${req.protocol}://${req.get('host')}/welcome?u=${encodeURIComponent(username)}&p=${tempPassword}`;
+        transporter.sendMail({
+          from: config.smtp.user,
+          to: email,
+          subject: 'Benvenuto in BTSMAP',
+          text: `Ciao ${username},\n\nIl tuo account è stato creato.\n\nCredenziali di accesso:\nUsername: ${username}\nPassword: ${tempPassword}\n\nVisita ${welcomeUrl} per accedere.\nTi consigliamo di cambiare la password dopo il primo accesso.`,
+        });
+
         res.status(201).json({ id: this.lastID, username, email, role: role || 'user' });
       }
     );

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -358,10 +358,8 @@
             <input type="email" id="newEmail" required />
             <label for="newEmail">Email</label>
           </div>
-          <div class="input-field col s12 m6">
-            <i class="material-icons prefix">lock</i>
-            <input type="password" id="newPassword" required />
-            <label for="newPassword">Password</label>
+          <div class="col s12 m6">
+            <p>Una password temporanea verrà inviata via email.</p>
           </div>
           <div class="input-field col s12 m6">
             <i class="material-icons prefix">security</i>
@@ -487,7 +485,6 @@ document.getElementById('userForm').addEventListener('submit', e => {
   const data = {
     username: document.getElementById('newUsername').value,
     email: document.getElementById('newEmail').value,
-    password: document.getElementById('newPassword').value,
     role: document.getElementById('newRole').value
   };
   fetch('/users', { method: 'POST', headers: tokenHeader(), body: JSON.stringify(data) })

--- a/frontend/welcome.html
+++ b/frontend/welcome.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <title>Benvenuto - BTSMAP</title>
+</head>
+<body>
+  <h1>Benvenuto su BTSMAP</h1>
+  <p>Il tuo account è stato creato. Usa le seguenti credenziali per accedere:</p>
+  <ul>
+    <li><strong>Username:</strong> <span id="username"></span></li>
+    <li><strong>Password:</strong> <span id="password"></span></li>
+  </ul>
+  <p><a href="index.html">Vai alla pagina di login</a></p>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    document.getElementById('username').textContent = params.get('u') || '';
+    document.getElementById('password').textContent = params.get('p') || '';
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Generate a temporary password when admins create users and email credentials with a welcome link
- Serve a new `/welcome` page showing the temporary credentials
- Remove manual password input from admin user creation form

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad8565d7b0832784ea6207de3cfd85