### PR TITLE
fix: handle 'all tags' selection correctly

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -422,11 +422,29 @@ if (markerTagContainer) {
 }
 
 function applyTagFilter() {
-  const selected = tagFilter
-    ? Array.from(tagFilter.selectedOptions)
-        .map((o) => o.value)
-        .filter(Boolean)
-    : [];
+  if (!tagFilter) return;
+
+  const options = Array.from(tagFilter.options);
+  let selectedValues = Array.from(tagFilter.selectedOptions).map(
+    (o) => o.value
+  );
+
+  if (
+    selectedValues.length === 0 ||
+    selectedValues.includes("") ||
+    selectedValues.length === options.length - 1
+  ) {
+    options.forEach((opt, idx) => (opt.selected = idx === 0));
+    selectedValues = [];
+  } else {
+    options[0].selected = false;
+  }
+
+  if (window.M && M.FormSelect) {
+    M.FormSelect.init(tagFilter, { dropdownOptions: { closeOnClick: false } });
+  }
+
+  const selected = selectedValues.filter(Boolean);
   Object.values(markersById).forEach(({ data, marker }) => {
     if (
       selected.length === 0 ||

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -801,7 +801,7 @@
               <button id="searchBtn" class="btn waves-effect">Cerca</button>
               <div class="tag-filter-field">
                 <select id="tagFilter" multiple>
-                  <option value="" disabled selected>Tutti i tag</option>
+                  <option value="" selected>Tutti i tag</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- enable selecting "Tutti i tag" option again in filter dropdown
- ensure selecting all tags toggles "Tutti i tag" and clears the filter logic

## Testing
- `npm test` (backend)
- `npm test` (root, fails: ENOENT no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b574fa1ee48327b7e2e5d4fc15a222